### PR TITLE
Centralize environment configuration

### DIFF
--- a/src/server/config.test.ts
+++ b/src/server/config.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// helper to import fresh module each time
+async function loadConfig() {
+  return await import('./config')
+}
+
+describe('config', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    delete (global as any).Deno
+  })
+
+  afterEach(() => {
+    delete (global as any).Deno
+  })
+
+  it('reads values from process.env in Node', async () => {
+    process.env.SUPABASE_URL = 'node-url'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'node-key'
+    const cfg = await loadConfig()
+    expect(cfg.SUPABASE_URL).toBe('node-url')
+    expect(cfg.SUPABASE_SERVICE_ROLE_KEY).toBe('node-key')
+  })
+
+  it('prefers Deno.env when available', async () => {
+    process.env.SUPABASE_URL = 'node-url'
+    ;(global as any).Deno = {
+      env: { toObject: () => ({ SUPABASE_URL: 'deno-url', SUPABASE_SERVICE_ROLE_KEY: 'deno-key' }) }
+    }
+    const cfg = await loadConfig()
+    expect(cfg.SUPABASE_URL).toBe('deno-url')
+    expect(cfg.SUPABASE_SERVICE_ROLE_KEY).toBe('deno-key')
+  })
+})

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,0 +1,13 @@
+// Centralized environment configuration for both Node and Deno runtimes
+
+const env: Record<string, string | undefined> =
+  typeof Deno !== 'undefined'
+    ? (Deno.env.toObject() as Record<string, string>)
+    : process.env;
+
+export const HUBSPOT_CLIENT_ID = env.HUBSPOT_CLIENT_ID ?? '';
+export const HUBSPOT_CLIENT_SECRET = env.HUBSPOT_CLIENT_SECRET ?? '';
+export const HUBSPOT_APP_SECRET = env.HUBSPOT_APP_SECRET ?? '';
+export const SUPABASE_URL = env.SUPABASE_URL ?? '';
+export const SUPABASE_SERVICE_ROLE_KEY =
+  env.SUPABASE_SERVICE_ROLE_KEY ?? env.SUPABASE_SERVICE_KEY ?? '';

--- a/src/server/hubspot_webhook.test.ts
+++ b/src/server/hubspot_webhook.test.ts
@@ -18,13 +18,16 @@ vi.mock('@supabase/supabase-js', () => ({
   })),
 }));
 
-import { hubspotWebhookHandler, jsonWithRaw } from './hubspot_webhook';
+let hubspotWebhookHandler: typeof import('./hubspot_webhook').hubspotWebhookHandler;
+let jsonWithRaw: typeof import('./hubspot_webhook').jsonWithRaw;
 
 const secret = 'test_secret';
 
-beforeEach(() => {
+beforeEach(async () => {
   insertMock.mockClear();
   process.env.HUBSPOT_APP_SECRET = secret;
+  vi.resetModules();
+  ({ hubspotWebhookHandler, jsonWithRaw } = await import('./hubspot_webhook'));
 });
 
 describe('hubspotWebhookHandler', () => {

--- a/src/server/hubspot_webhook.ts
+++ b/src/server/hubspot_webhook.ts
@@ -2,10 +2,11 @@ import express, { RequestHandler, Request, Response } from 'express';
 import { requireAuth } from '@clerk/express';
 import { createClient } from '@supabase/supabase-js';
 import { createHmac } from 'crypto';
-
-const HUBSPOT_SECRET = process.env.HUBSPOT_APP_SECRET || 'test_secret';
-const SUPABASE_URL = process.env.SUPABASE_URL || '';
-const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+import {
+  HUBSPOT_APP_SECRET as HUBSPOT_SECRET,
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+} from './config';
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 

--- a/src/server/post_note.ts
+++ b/src/server/post_note.ts
@@ -1,10 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
 import crypto from 'crypto';
-
-const SUPABASE_URL = process.env.SUPABASE_URL || '';
-const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
-const HUBSPOT_CLIENT_ID = process.env.HUBSPOT_CLIENT_ID || '';
-const HUBSPOT_CLIENT_SECRET = process.env.HUBSPOT_CLIENT_SECRET || '';
+import {
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+  HUBSPOT_CLIENT_ID,
+  HUBSPOT_CLIENT_SECRET,
+} from './config';
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 

--- a/src/server/search_contacts.ts
+++ b/src/server/search_contacts.ts
@@ -1,10 +1,11 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js'
 import rateLimiter from './rate_limiter_memory'
-
-const SUPABASE_URL = process.env.SUPABASE_URL || ''
-const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || ''
-const HUBSPOT_CLIENT_ID = process.env.HUBSPOT_CLIENT_ID || ''
-const HUBSPOT_CLIENT_SECRET = process.env.HUBSPOT_CLIENT_SECRET || ''
+import {
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+  HUBSPOT_CLIENT_ID,
+  HUBSPOT_CLIENT_SECRET,
+} from './config'
 
 export interface ContactRecord {
   id: string

--- a/supabase/functions/hubspot_oauth_callback.ts
+++ b/supabase/functions/hubspot_oauth_callback.ts
@@ -1,14 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from '../src/integrations/supabase/types';
-
-// Resolve environment variables for both Node and Deno environments
-const env: Record<string, string | undefined> =
-  typeof Deno !== 'undefined' ? (Deno.env.toObject() as Record<string, string>) : process.env;
-
-const HUBSPOT_CLIENT_ID = env.HUBSPOT_CLIENT_ID ?? '';
-const HUBSPOT_CLIENT_SECRET = env.HUBSPOT_CLIENT_SECRET ?? '';
-const SUPABASE_URL = env.SUPABASE_URL ?? '';
-const SUPABASE_SERVICE_ROLE_KEY = env.SUPABASE_SERVICE_ROLE_KEY ?? env.SUPABASE_SERVICE_KEY ?? '';
+import {
+  HUBSPOT_CLIENT_ID,
+  HUBSPOT_CLIENT_SECRET,
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+} from '../src/server/config.ts';
 
 const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 


### PR DESCRIPTION
## Summary
- add a shared configuration module for credentials
- wire server code and HubSpot OAuth function to use this module
- update webhook test to load module after setting env
- test that configuration works for Node and Deno

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6857099717b88323a0190a2265e11f5a