### PR TITLE
Refactor HubSpot token management

### DIFF
--- a/hubspot_oauth_callback.test.ts
+++ b/hubspot_oauth_callback.test.ts
@@ -10,7 +10,7 @@ vi.mock('@supabase/supabase-js', () => ({
 }));
 
 const fetchMock = vi.fn();
-// @ts-ignore
+// @ts-expect-error test environment does not provide fetch typing
 global.fetch = fetchMock;
 
 describe('hubspotOAuthCallback', () => {

--- a/src/server/hubspot_auth.test.ts
+++ b/src/server/hubspot_auth.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+process.env.SUPABASE_URL = 'http://localhost'
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'key'
+
+let ensureAccessToken: typeof import('./hubspot_auth').ensureAccessToken
+beforeAll(async () => {
+  ;({ ensureAccessToken } = await import('./hubspot_auth'))
+})
+
+const selectMock = vi.fn()
+const updateMock = vi.fn()
+
+const mockSb = {
+  from: () => ({
+    select: () => ({
+      eq: () => ({ maybeSingle: selectMock })
+    }),
+    update: updateMock
+  })
+} as unknown as SupabaseClient
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchMock = vi.fn()
+  selectMock.mockReset()
+  updateMock.mockReset()
+})
+
+describe('ensureAccessToken', () => {
+  it('returns current token when not expired', async () => {
+    selectMock.mockResolvedValue({ data: { access_token: 'tok', refresh_token: 'ref', expires_at: new Date(Date.now()+3600e3).toISOString() }, error: null })
+
+    const tok = await ensureAccessToken('p1', mockSb, fetchMock)
+    expect(tok).toBe('tok')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('refreshes expired token', async () => {
+    const expired = new Date(Date.now()-1000).toISOString()
+    selectMock.mockResolvedValue({ data: { access_token: 'old', refresh_token: 'ref', expires_at: expired }, error: null })
+    updateMock.mockReturnValue({ eq: () => Promise.resolve({}) })
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ access_token: 'new', refresh_token: 'newr', expires_in: 3600 }) })
+
+    const tok = await ensureAccessToken('p1', mockSb, fetchMock)
+    expect(fetchMock).toHaveBeenCalled()
+    expect(updateMock).toHaveBeenCalled()
+    expect(tok).toBe('new')
+  })
+})

--- a/src/server/hubspot_auth.ts
+++ b/src/server/hubspot_auth.ts
@@ -1,0 +1,57 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || '';
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+const HUBSPOT_CLIENT_ID = process.env.HUBSPOT_CLIENT_ID || '';
+const HUBSPOT_CLIENT_SECRET = process.env.HUBSPOT_CLIENT_SECRET || '';
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+export async function ensureAccessToken(
+  portalId: string,
+  sb: SupabaseClient = supabase,
+  fetchFn: typeof fetch = fetch
+): Promise<string> {
+  const { data, error } = await sb
+    .from('hubspot_tokens')
+    .select('access_token, refresh_token, expires_at')
+    .eq('portal_id', portalId)
+    .maybeSingle();
+
+  if (error || !data) {
+    throw new Error('Token fetch failed');
+  }
+
+  if (data.expires_at && new Date(data.expires_at).getTime() > Date.now() + 60_000) {
+    return data.access_token;
+  }
+
+  const resp = await fetchFn('https://api.hubapi.com/oauth/v1/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: data.refresh_token,
+      client_id: HUBSPOT_CLIENT_ID,
+      client_secret: HUBSPOT_CLIENT_SECRET,
+    }).toString(),
+  });
+
+  if (!resp.ok) throw new Error('Refresh failed');
+  const json = (await resp.json()) as {
+    access_token: string
+    refresh_token?: string
+    expires_in: number
+  }
+
+  await sb
+    .from('hubspot_tokens')
+    .update({
+      access_token: json.access_token,
+      refresh_token: json.refresh_token ?? data.refresh_token,
+      expires_at: new Date(Date.now() + json.expires_in * 1000).toISOString(),
+    })
+    .eq('portal_id', portalId);
+
+  return json.access_token;
+}

--- a/src/server/post_note.test.ts
+++ b/src/server/post_note.test.ts
@@ -15,7 +15,7 @@ vi.mock('@supabase/supabase-js', () => ({
   })),
 }));
 
-let fetchMock: any;
+let fetchMock: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   fetchMock = vi.fn();

--- a/src/server/post_note.ts
+++ b/src/server/post_note.ts
@@ -1,10 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
+import { ensureAccessToken } from './hubspot_auth';
 import crypto from 'crypto';
 
 const SUPABASE_URL = process.env.SUPABASE_URL || '';
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
-const HUBSPOT_CLIENT_ID = process.env.HUBSPOT_CLIENT_ID || '';
-const HUBSPOT_CLIENT_SECRET = process.env.HUBSPOT_CLIENT_SECRET || '';
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
@@ -50,52 +49,12 @@ function limiterFor(token: string) {
   return limiters.get(token)!;
 }
 
-async function ensureAccessToken(portal_id: string): Promise<string> {
-  const { data, error } = await supabase
-    .from('hubspot_tokens')
-    .select('access_token, refresh_token, expires_at')
-    .eq('portal_id', portal_id)
-    .maybeSingle();
-
-  if (error || !data) {
-    throw new Error('Token fetch failed');
-  }
-
-  if (data.expires_at && new Date(data.expires_at).getTime() > Date.now() + 60_000) {
-    return data.access_token;
-  }
-
-  const resp = await fetch('https://api.hubapi.com/oauth/v1/token', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: data.refresh_token,
-      client_id: HUBSPOT_CLIENT_ID,
-      client_secret: HUBSPOT_CLIENT_SECRET,
-    }).toString(),
-  });
-
-  if (!resp.ok) throw new Error('Refresh failed');
-  const json: any = await resp.json();
-
-  await supabase
-    .from('hubspot_tokens')
-    .update({
-      access_token: json.access_token,
-      refresh_token: json.refresh_token ?? data.refresh_token,
-      expires_at: new Date(Date.now() + json.expires_in * 1000).toISOString(),
-    })
-    .eq('portal_id', portal_id);
-
-  return json.access_token;
-}
 
 export async function postNote({
   portal_id,
   hubspot_object_id,
   app_record_url,
-}: PostNoteInput): Promise<{ noteId: string } | { error: any }> {
+}: PostNoteInput): Promise<{ noteId: string } | { error: unknown }> {
   try {
     const accessToken = await ensureAccessToken(portal_id);
     const limiter = limiterFor(accessToken);

--- a/src/server/search_contacts.ts
+++ b/src/server/search_contacts.ts
@@ -1,58 +1,17 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js'
 import rateLimiter from './rate_limiter_memory'
+import { ensureAccessToken } from './hubspot_auth'
 
 const SUPABASE_URL = process.env.SUPABASE_URL || ''
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || ''
-const HUBSPOT_CLIENT_ID = process.env.HUBSPOT_CLIENT_ID || ''
-const HUBSPOT_CLIENT_SECRET = process.env.HUBSPOT_CLIENT_SECRET || ''
 
 export interface ContactRecord {
   id: string
-  properties: Record<string, any>
+  properties: Record<string, unknown>
 }
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 
-async function ensureAccessToken(portal_id: string, sb: SupabaseClient = supabase): Promise<string> {
-  const { data, error } = await sb
-    .from('hubspot_tokens')
-    .select('access_token, refresh_token, expires_at')
-    .eq('portal_id', portal_id)
-    .maybeSingle()
-
-  if (error || !data) {
-    throw new Error('Token fetch failed')
-  }
-
-  if (data.expires_at && new Date(data.expires_at).getTime() > Date.now() + 60_000) {
-    return data.access_token
-  }
-
-  const resp = await fetch('https://api.hubapi.com/oauth/v1/token', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: data.refresh_token,
-      client_id: HUBSPOT_CLIENT_ID,
-      client_secret: HUBSPOT_CLIENT_SECRET,
-    }).toString(),
-  })
-
-  if (!resp.ok) throw new Error('Refresh failed')
-  const json: any = await resp.json()
-
-  await sb
-    .from('hubspot_tokens')
-    .update({
-      access_token: json.access_token,
-      refresh_token: json.refresh_token ?? data.refresh_token,
-      expires_at: new Date(Date.now() + json.expires_in * 1000).toISOString(),
-    })
-    .eq('portal_id', portal_id)
-
-  return json.access_token
-}
 
 export async function searchLocal(
   portal_id: string,
@@ -99,7 +58,9 @@ async function searchRemote(
   })
 
   if (!response.ok) throw new Error('HubSpot search failed')
-  const json: any = await response.json()
+  const json = (await response.json()) as {
+    results?: ContactRecord[]
+  }
   const rows: ContactRecord[] = json.results || []
   const now = new Date().toISOString()
   if (rows.length) {
@@ -119,7 +80,7 @@ export async function searchContacts(
 ): Promise<ContactRecord[]> {
   const local = await searchLocal(portal_id, q, limit, sb)
   const seen = new Set(local.map(r => r.id))
-  let results = [...local]
+  const results = [...local]
   if (results.length < 5) {
     const remote = await searchRemote(portal_id, q, limit, sb, fetchFn)
     for (const r of remote) {


### PR DESCRIPTION
## Summary
- centralize HubSpot token refresh logic in `hubspot_auth.ts`
- refactor `post_note.ts` and `search_contacts.ts` to use shared helper
- add unit test for `ensureAccessToken`
- fix lint issues in tests

## Testing
- `npm test`
- `npm run test:jest`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68570967ca28832394e07b4552d0483b