### PR TITLE
Add HubSpot table types

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -36,6 +36,91 @@ export type Database = {
         }
         Relationships: []
       }
+      hubspot_tokens: {
+        Row: {
+          portal_id: string
+          access_token: string | null
+          refresh_token: string | null
+          expires_at: string | null
+          scope: string[] | null
+        }
+        Insert: {
+          portal_id: string
+          access_token?: string | null
+          refresh_token?: string | null
+          expires_at?: string | null
+          scope?: string[] | null
+        }
+        Update: {
+          portal_id?: string
+          access_token?: string | null
+          refresh_token?: string | null
+          expires_at?: string | null
+          scope?: string[] | null
+        }
+        Relationships: []
+      }
+      hubspot_events_raw: {
+        Row: {
+          id: number
+          portal_id: string | null
+          raw: Json | null
+          received_at: string | null
+        }
+        Insert: {
+          id?: number
+          portal_id?: string | null
+          raw?: Json | null
+          received_at?: string | null
+        }
+        Update: {
+          id?: number
+          portal_id?: string | null
+          raw?: Json | null
+          received_at?: string | null
+        }
+        Relationships: []
+      }
+      hubspot_contacts_cache: {
+        Row: {
+          portal_id: string
+          id: string
+          properties: Json | null
+          updated_at: string | null
+          search_vector: unknown | null
+        }
+        Insert: {
+          portal_id: string
+          id: string
+          properties?: Json | null
+          updated_at?: string | null
+        }
+        Update: {
+          portal_id?: string
+          id?: string
+          properties?: Json | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      hubspot_sync_cursors: {
+        Row: {
+          portal_id: string
+          object_type: string
+          hs_timestamp: string | null
+        }
+        Insert: {
+          portal_id: string
+          object_type: string
+          hs_timestamp?: string | null
+        }
+        Update: {
+          portal_id?: string
+          object_type?: string
+          hs_timestamp?: string | null
+        }
+        Relationships: []
+      }
     }
     Views: {
       [_ in never]: never

--- a/src/server/post_note.ts
+++ b/src/server/post_note.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import type { Database } from '../integrations/supabase/types';
 import crypto from 'crypto';
 
 const SUPABASE_URL = process.env.SUPABASE_URL || '';
@@ -6,7 +7,7 @@ const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
 const HUBSPOT_CLIENT_ID = process.env.HUBSPOT_CLIENT_ID || '';
 const HUBSPOT_CLIENT_SECRET = process.env.HUBSPOT_CLIENT_SECRET || '';
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
 export interface PostNoteInput {
   portal_id: string;

--- a/src/server/search_contacts.ts
+++ b/src/server/search_contacts.ts
@@ -1,4 +1,5 @@
-import { createClient, SupabaseClient } from '@supabase/supabase-js'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '../integrations/supabase/types'
 import rateLimiter from './rate_limiter_memory'
 
 const SUPABASE_URL = process.env.SUPABASE_URL || ''
@@ -11,9 +12,9 @@ export interface ContactRecord {
   properties: Record<string, any>
 }
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 
-async function ensureAccessToken(portal_id: string, sb: SupabaseClient = supabase): Promise<string> {
+async function ensureAccessToken(portal_id: string, sb: SupabaseClient<Database> = supabase): Promise<string> {
   const { data, error } = await sb
     .from('hubspot_tokens')
     .select('access_token, refresh_token, expires_at')
@@ -58,7 +59,7 @@ export async function searchLocal(
   portal_id: string,
   q: string,
   limit: number,
-  sb: SupabaseClient = supabase
+  sb: SupabaseClient<Database> = supabase
 ): Promise<ContactRecord[]> {
   const { data } = await sb
     .from('hubspot_contacts_cache')
@@ -73,7 +74,7 @@ async function searchRemote(
   portal_id: string,
   q: string,
   limit: number,
-  sb: SupabaseClient = supabase,
+  sb: SupabaseClient<Database> = supabase,
   fetchFn: typeof fetch = fetch
 ): Promise<ContactRecord[]> {
   const accessToken = await ensureAccessToken(portal_id, sb)
@@ -114,7 +115,7 @@ export async function searchContacts(
   portal_id: string,
   q: string,
   limit: number,
-  sb: SupabaseClient = supabase,
+  sb: SupabaseClient<Database> = supabase,
   fetchFn: typeof fetch = fetch
 ): Promise<ContactRecord[]> {
   const local = await searchLocal(portal_id, q, limit, sb)


### PR DESCRIPTION
## Summary
- add HubSpot tables to Supabase types
- type Supabase clients in server functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68570983204c8323906bcbfe30064e69