### PR TITLE
Implement per-portal rate limiting

### DIFF
--- a/src/server/rate_limiter_memory.ts
+++ b/src/server/rate_limiter_memory.ts
@@ -1,6 +1,6 @@
 export interface BucketState {
-  tokens: number;
-  resetAt: number;
+  tokens: number
+  resetAt: number
 }
 
 function delay(ms: number) {
@@ -8,7 +8,7 @@ function delay(ms: number) {
 }
 
 export class RateLimiterMemory {
-  private buckets: Map<string, BucketState> = new Map();
+  private buckets: Map<string, BucketState> = new Map()
 
   constructor(private maxBurst = 100, private windowMs = 10_000) {}
 
@@ -37,6 +37,18 @@ export class RateLimiterMemory {
     return this.take(id, cost);
   }
 }
+const portalLimiters = new Map<string, RateLimiterMemory>()
 
-const rateLimiterMemory = new RateLimiterMemory();
-export default rateLimiterMemory;
+export function getLimiter(
+  id: string,
+  maxBurst = 100,
+  windowMs = 10_000
+) {
+  if (!portalLimiters.has(id)) {
+    portalLimiters.set(id, new RateLimiterMemory(maxBurst, windowMs))
+  }
+  return portalLimiters.get(id)!
+}
+
+const rateLimiterMemory = getLimiter('default', 4, 1_000)
+export default rateLimiterMemory


### PR DESCRIPTION
## Summary
- add `getLimiter` helper to return per-id `RateLimiterMemory`
- apply shared rate limiter to `post_note`
- test throttling behaviour with the shared limiter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6857096ff03c83238be7759df7b1d94f