### PR TITLE
Add HubSpot token utilities

### DIFF
--- a/src/integrations/hubspot/token.ts
+++ b/src/integrations/hubspot/token.ts
@@ -1,0 +1,71 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '../supabase/types'
+import {
+  HUBSPOT_CLIENT_ID,
+  HUBSPOT_CLIENT_SECRET,
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+} from '../../server/config'
+
+const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+
+export async function refreshToken(
+  portalId: string,
+  sb: SupabaseClient<Database> = supabase,
+): Promise<string> {
+  const { data, error } = await sb
+    .from('hubspot_tokens')
+    .select('refresh_token')
+    .eq('portal_id', portalId)
+    .maybeSingle()
+
+  if (error || !data?.refresh_token) {
+    throw new Error('Token fetch failed')
+  }
+
+  const resp = await fetch('https://api.hubapi.com/oauth/v1/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: data.refresh_token,
+      client_id: HUBSPOT_CLIENT_ID,
+      client_secret: HUBSPOT_CLIENT_SECRET,
+    }).toString(),
+  })
+
+  if (!resp.ok) throw new Error('Refresh failed')
+  const json: any = await resp.json()
+
+  await sb
+    .from('hubspot_tokens')
+    .update({
+      access_token: json.access_token,
+      refresh_token: json.refresh_token ?? data.refresh_token,
+      expires_at: new Date(Date.now() + json.expires_in * 1000).toISOString(),
+    })
+    .eq('portal_id', portalId)
+
+  return json.access_token
+}
+
+export async function getAccessToken(
+  portalId: string,
+  sb: SupabaseClient<Database> = supabase,
+): Promise<string> {
+  const { data, error } = await sb
+    .from('hubspot_tokens')
+    .select('access_token, expires_at')
+    .eq('portal_id', portalId)
+    .maybeSingle()
+
+  if (error || !data) {
+    throw new Error('Token fetch failed')
+  }
+
+  if (data.expires_at && new Date(data.expires_at).getTime() > Date.now() + 60_000) {
+    return data.access_token
+  }
+
+  return refreshToken(portalId, sb)
+}

--- a/src/server/post_note.ts
+++ b/src/server/post_note.ts
@@ -4,9 +4,8 @@ import crypto from 'crypto';
 import {
   SUPABASE_URL,
   SUPABASE_SERVICE_ROLE_KEY,
-  HUBSPOT_CLIENT_ID,
-  HUBSPOT_CLIENT_SECRET,
 } from './config';
+import { getAccessToken } from '../integrations/hubspot/token';
 
 const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
@@ -52,46 +51,6 @@ function limiterFor(token: string) {
   return limiters.get(token)!;
 }
 
-async function ensureAccessToken(portal_id: string): Promise<string> {
-  const { data, error } = await supabase
-    .from('hubspot_tokens')
-    .select('access_token, refresh_token, expires_at')
-    .eq('portal_id', portal_id)
-    .maybeSingle();
-
-  if (error || !data) {
-    throw new Error('Token fetch failed');
-  }
-
-  if (data.expires_at && new Date(data.expires_at).getTime() > Date.now() + 60_000) {
-    return data.access_token;
-  }
-
-  const resp = await fetch('https://api.hubapi.com/oauth/v1/token', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: data.refresh_token,
-      client_id: HUBSPOT_CLIENT_ID,
-      client_secret: HUBSPOT_CLIENT_SECRET,
-    }).toString(),
-  });
-
-  if (!resp.ok) throw new Error('Refresh failed');
-  const json: any = await resp.json();
-
-  await supabase
-    .from('hubspot_tokens')
-    .update({
-      access_token: json.access_token,
-      refresh_token: json.refresh_token ?? data.refresh_token,
-      expires_at: new Date(Date.now() + json.expires_in * 1000).toISOString(),
-    })
-    .eq('portal_id', portal_id);
-
-  return json.access_token;
-}
 
 export async function postNote({
   portal_id,
@@ -99,7 +58,7 @@ export async function postNote({
   app_record_url,
 }: PostNoteInput): Promise<{ noteId: string } | { error: any }> {
   try {
-    const accessToken = await ensureAccessToken(portal_id);
+    const accessToken = await getAccessToken(portal_id);
     const limiter = limiterFor(accessToken);
     const response = await limiter.schedule(() =>
       fetch('https://api.hubapi.com/crm/v3/objects/notes', {

--- a/src/server/search_contacts.ts
+++ b/src/server/search_contacts.ts
@@ -4,9 +4,8 @@ import rateLimiter from './rate_limiter_memory'
 import {
   SUPABASE_URL,
   SUPABASE_SERVICE_ROLE_KEY,
-  HUBSPOT_CLIENT_ID,
-  HUBSPOT_CLIENT_SECRET,
 } from './config'
+import { getAccessToken } from '../integrations/hubspot/token'
 
 export interface ContactRecord {
   id: string
@@ -15,46 +14,6 @@ export interface ContactRecord {
 
 const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 
-async function ensureAccessToken(portal_id: string, sb: SupabaseClient<Database> = supabase): Promise<string> {
-  const { data, error } = await sb
-    .from('hubspot_tokens')
-    .select('access_token, refresh_token, expires_at')
-    .eq('portal_id', portal_id)
-    .maybeSingle()
-
-  if (error || !data) {
-    throw new Error('Token fetch failed')
-  }
-
-  if (data.expires_at && new Date(data.expires_at).getTime() > Date.now() + 60_000) {
-    return data.access_token
-  }
-
-  const resp = await fetch('https://api.hubapi.com/oauth/v1/token', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: data.refresh_token,
-      client_id: HUBSPOT_CLIENT_ID,
-      client_secret: HUBSPOT_CLIENT_SECRET,
-    }).toString(),
-  })
-
-  if (!resp.ok) throw new Error('Refresh failed')
-  const json: any = await resp.json()
-
-  await sb
-    .from('hubspot_tokens')
-    .update({
-      access_token: json.access_token,
-      refresh_token: json.refresh_token ?? data.refresh_token,
-      expires_at: new Date(Date.now() + json.expires_in * 1000).toISOString(),
-    })
-    .eq('portal_id', portal_id)
-
-  return json.access_token
-}
 
 export async function searchLocal(
   portal_id: string,
@@ -78,7 +37,7 @@ async function searchRemote(
   sb: SupabaseClient<Database> = supabase,
   fetchFn: typeof fetch = fetch
 ): Promise<ContactRecord[]> {
-  const accessToken = await ensureAccessToken(portal_id, sb)
+  const accessToken = await getAccessToken(portal_id, sb)
   await rateLimiter.take(portal_id)
   const response = await fetchFn('https://api.hubapi.com/crm/v3/objects/contacts/search', {
     method: 'POST',


### PR DESCRIPTION
## Summary
- centralize access token refresh logic under integrations/hubspot
- use new helpers in search and note server modules

## Testing
- `npm run lint` *(fails: Unexpected any in many files)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68571758889c8323b62a8e62cf5ed8ed