### PR TITLE
Refactor HubSpot token handling

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,4 +1,5 @@
 // Centralized environment configuration for both Node and Deno runtimes
+declare const Deno: undefined | { env: { toObject(): Record<string, string> } }
 
 const env: Record<string, string | undefined> =
   typeof Deno !== 'undefined'

--- a/src/server/hubspot_tokens.test.ts
+++ b/src/server/hubspot_tokens.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ensureAccessToken } from "./hubspot_tokens";
+
+const selectMock = vi.fn();
+const updateMock = vi.fn();
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => ({
+    from: () => ({ select: selectMock, update: updateMock }),
+  })),
+}));
+
+let fetchMock: any;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+  selectMock.mockReset();
+  updateMock.mockReset();
+});
+
+describe("ensureAccessToken", () => {
+  it("returns existing token when not expired", async () => {
+    selectMock.mockReturnValue({
+      eq: () => ({
+        maybeSingle: () =>
+          Promise.resolve({
+            data: {
+              access_token: "tok",
+              refresh_token: "ref",
+              expires_at: new Date(Date.now() + 3600e3).toISOString(),
+            },
+            error: null,
+          }),
+      }),
+    });
+
+    const token = await ensureAccessToken("p1");
+
+    expect(token).toBe("tok");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes expired token", async () => {
+    const expired = new Date(Date.now() - 1000).toISOString();
+    selectMock.mockReturnValue({
+      eq: () => ({
+        maybeSingle: () =>
+          Promise.resolve({
+            data: {
+              access_token: "old",
+              refresh_token: "ref",
+              expires_at: expired,
+            },
+            error: null,
+          }),
+      }),
+    });
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        access_token: "new",
+        refresh_token: "newref",
+        expires_in: 3600,
+      }),
+    });
+    updateMock.mockReturnValue({ eq: () => Promise.resolve({}) });
+
+    const token = await ensureAccessToken("p1");
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(updateMock).toHaveBeenCalled();
+    expect(token).toBe("new");
+  });
+});

--- a/src/server/hubspot_tokens.ts
+++ b/src/server/hubspot_tokens.ts
@@ -1,0 +1,54 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '../integrations/supabase/types'
+import {
+  HUBSPOT_CLIENT_ID,
+  HUBSPOT_CLIENT_SECRET,
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+} from './config'
+
+const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+
+export async function ensureAccessToken(
+  portal_id: string,
+  sb: SupabaseClient<Database> = supabase
+): Promise<string> {
+  const { data, error } = await sb
+    .from('hubspot_tokens')
+    .select('access_token, refresh_token, expires_at')
+    .eq('portal_id', portal_id)
+    .maybeSingle()
+
+  if (error || !data) {
+    throw new Error('Token fetch failed')
+  }
+
+  if (data.expires_at && new Date(data.expires_at).getTime() > Date.now() + 60_000) {
+    return data.access_token
+  }
+
+  const resp = await fetch('https://api.hubapi.com/oauth/v1/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: data.refresh_token,
+      client_id: HUBSPOT_CLIENT_ID,
+      client_secret: HUBSPOT_CLIENT_SECRET,
+    }).toString(),
+  })
+
+  if (!resp.ok) throw new Error('Refresh failed')
+  const json: any = await resp.json()
+
+  await sb
+    .from('hubspot_tokens')
+    .update({
+      access_token: json.access_token,
+      refresh_token: json.refresh_token ?? data.refresh_token,
+      expires_at: new Date(Date.now() + json.expires_in * 1000).toISOString(),
+    })
+    .eq('portal_id', portal_id)
+
+  return json.access_token
+}

--- a/src/server/post_note.ts
+++ b/src/server/post_note.ts
@@ -4,9 +4,8 @@ import crypto from 'crypto';
 import {
   SUPABASE_URL,
   SUPABASE_SERVICE_ROLE_KEY,
-  HUBSPOT_CLIENT_ID,
-  HUBSPOT_CLIENT_SECRET,
 } from './config';
+import { ensureAccessToken } from './hubspot_tokens';
 
 const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
@@ -50,47 +49,6 @@ function limiterFor(token: string) {
     limiters.set(token, new SimpleLimiter(250));
   }
   return limiters.get(token)!;
-}
-
-async function ensureAccessToken(portal_id: string): Promise<string> {
-  const { data, error } = await supabase
-    .from('hubspot_tokens')
-    .select('access_token, refresh_token, expires_at')
-    .eq('portal_id', portal_id)
-    .maybeSingle();
-
-  if (error || !data) {
-    throw new Error('Token fetch failed');
-  }
-
-  if (data.expires_at && new Date(data.expires_at).getTime() > Date.now() + 60_000) {
-    return data.access_token;
-  }
-
-  const resp = await fetch('https://api.hubapi.com/oauth/v1/token', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: data.refresh_token,
-      client_id: HUBSPOT_CLIENT_ID,
-      client_secret: HUBSPOT_CLIENT_SECRET,
-    }).toString(),
-  });
-
-  if (!resp.ok) throw new Error('Refresh failed');
-  const json: any = await resp.json();
-
-  await supabase
-    .from('hubspot_tokens')
-    .update({
-      access_token: json.access_token,
-      refresh_token: json.refresh_token ?? data.refresh_token,
-      expires_at: new Date(Date.now() + json.expires_in * 1000).toISOString(),
-    })
-    .eq('portal_id', portal_id);
-
-  return json.access_token;
 }
 
 export async function postNote({

--- a/src/server/search_contacts.test.ts
+++ b/src/server/search_contacts.test.ts
@@ -4,6 +4,10 @@ jest.mock('./rate_limiter_memory', () => {
   const { RateLimiterMemory } = jest.requireActual('./rate_limiter_memory')
   return { __esModule: true, default: new RateLimiterMemory(100, 1000), RateLimiterMemory }
 })
+jest.mock('./hubspot_tokens.ts', () => ({
+  __esModule: true,
+  ensureAccessToken: jest.fn(() => Promise.resolve('tok')),
+}))
 import { RateLimiterMemory } from './rate_limiter_memory'
 let searchContacts: typeof import('./search_contacts').searchContacts
 beforeAll(async () => {

--- a/src/server/search_contacts.ts
+++ b/src/server/search_contacts.ts
@@ -4,9 +4,8 @@ import rateLimiter from './rate_limiter_memory'
 import {
   SUPABASE_URL,
   SUPABASE_SERVICE_ROLE_KEY,
-  HUBSPOT_CLIENT_ID,
-  HUBSPOT_CLIENT_SECRET,
 } from './config'
+import { ensureAccessToken } from './hubspot_tokens'
 
 export interface ContactRecord {
   id: string
@@ -14,47 +13,6 @@ export interface ContactRecord {
 }
 
 const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
-
-async function ensureAccessToken(portal_id: string, sb: SupabaseClient<Database> = supabase): Promise<string> {
-  const { data, error } = await sb
-    .from('hubspot_tokens')
-    .select('access_token, refresh_token, expires_at')
-    .eq('portal_id', portal_id)
-    .maybeSingle()
-
-  if (error || !data) {
-    throw new Error('Token fetch failed')
-  }
-
-  if (data.expires_at && new Date(data.expires_at).getTime() > Date.now() + 60_000) {
-    return data.access_token
-  }
-
-  const resp = await fetch('https://api.hubapi.com/oauth/v1/token', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: data.refresh_token,
-      client_id: HUBSPOT_CLIENT_ID,
-      client_secret: HUBSPOT_CLIENT_SECRET,
-    }).toString(),
-  })
-
-  if (!resp.ok) throw new Error('Refresh failed')
-  const json: any = await resp.json()
-
-  await sb
-    .from('hubspot_tokens')
-    .update({
-      access_token: json.access_token,
-      refresh_token: json.refresh_token ?? data.refresh_token,
-      expires_at: new Date(Date.now() + json.expires_in * 1000).toISOString(),
-    })
-    .eq('portal_id', portal_id)
-
-  return json.access_token
-}
 
 export async function searchLocal(
   portal_id: string,

--- a/src/server/search_contacts.ts
+++ b/src/server/search_contacts.ts
@@ -5,6 +5,13 @@ import {
   SUPABASE_URL,
   SUPABASE_SERVICE_ROLE_KEY,
 } from './config'
+import { ensureAccessToken as getAccessToken } from './hubspot_tokens'
+async function ensureAccessToken(
+  portal_id: string,
+  sb: SupabaseClient<Database> = supabase
+): Promise<string> {
+  return getAccessToken(portal_id, sb)
+}
 
 import { ensureAccessToken } from './hubspot_tokens'
 


### PR DESCRIPTION
## Summary
- create `hubspot_tokens` helper with `ensureAccessToken`
- reuse helper in `search_contacts` and `post_note`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run test:jest` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685715e6bf648323b3e962cc9d49b571