### PR TITLE
Define HubSpot token interface

### DIFF
--- a/src/integrations/hubspot/tokens.ts
+++ b/src/integrations/hubspot/tokens.ts
@@ -9,6 +9,13 @@ import {
 
 const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 
+export interface HubSpotTokenResponse {
+  access_token: string
+  refresh_token?: string
+  expires_in: number
+  scope?: string
+}
+
 export async function ensureAccessToken(
   portal_id: string,
   sb: SupabaseClient<Database> = supabase,
@@ -40,7 +47,7 @@ export async function ensureAccessToken(
   })
 
   if (!resp.ok) throw new Error('Refresh failed')
-  const json: any = await resp.json()
+  const json: HubSpotTokenResponse = await resp.json()
 
   await sb
     .from('hubspot_tokens')


### PR DESCRIPTION
## Summary
- add `HubSpotTokenResponse` type
- use this interface when refreshing HubSpot access tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68574591e4ec83238bbc2f73a0fe2331