### PR TITLE
Introduce supabase service client helper

### DIFF
--- a/src/integrations/hubspot/client.ts
+++ b/src/integrations/hubspot/client.ts
@@ -1,11 +1,9 @@
-import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '../supabase/types'
 import rateLimiter from '../../server/rate_limiter_memory'
-import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from '../../server/config'
+import supabase from '../../server/supabaseClient'
 import { ensureAccessToken } from './tokens'
 import crypto from 'crypto'
-
-const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 
 export interface HubSpotContact {
   id: string

--- a/src/integrations/hubspot/tokens.ts
+++ b/src/integrations/hubspot/tokens.ts
@@ -1,13 +1,11 @@
-import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '../supabase/types'
+import supabase from '../../server/supabaseClient'
 import {
-  SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY,
   HUBSPOT_CLIENT_ID,
   HUBSPOT_CLIENT_SECRET,
 } from '../../server/config'
 
-const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 
 export async function ensureAccessToken(
   portal_id: string,

--- a/src/server/search_contacts.ts
+++ b/src/server/search_contacts.ts
@@ -5,6 +5,7 @@ import {
   SUPABASE_URL,
   SUPABASE_SERVICE_ROLE_KEY,
 } from './config'
+import supabase from './supabaseClient'
 
 import { searchContacts as hubspotSearch } from '../integrations/hubspot/client'
 
@@ -13,7 +14,6 @@ export interface ContactRecord {
   properties: Record<string, any>
 }
 
-const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 
 export async function searchLocal(
   portal_id: string,

--- a/src/server/supabaseClient.ts
+++ b/src/server/supabaseClient.ts
@@ -1,0 +1,7 @@
+import { createClient } from '@supabase/supabase-js'
+import type { Database } from '../integrations/supabase/types'
+import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
+
+const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+
+export default supabase


### PR DESCRIPTION
## Summary
- add a supabase service-role helper
- use the helper in HubSpot integration clients
- use the helper in search contacts

## Testing
- `npm test`
- `npm run test:jest` *(fails: search_contacts.test.ts)*

------
https://chatgpt.com/codex/tasks/task_b_6857459501c083239e5891aa70798e13