### PR TITLE
Implement HubSpot uninstall cleanup

### DIFF
--- a/docs/SECURITY_CHECKLIST.md
+++ b/docs/SECURITY_CHECKLIST.md
@@ -3,7 +3,7 @@
 - [ ] Clerk JWT TTL ≤ 1 h, Supabase JWKS set
 - [ ] Tokens encrypted in Vault, rotated quarterly
 - [ ] Scopes: crm.objects.*.read + notes.write only
-- [ ] Purge tokens & cache rows on uninstall webhook
+- [x] Purge tokens & cache rows on uninstall webhook
 - [ ] GDPR delete handler truncates cache & notes
 - [ ] Nightly cron runs with service-role but writes through RLS-safe function
 - [ ] HSTS + HTTPS redirect

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -55,3 +55,10 @@ paths:
       responses:
         "200":
           description: Authorization successful
+  /hubspot_uninstall:
+    post:
+      security:
+        - bearerAuth: []
+      responses:
+        "204":
+          description: Tokens and cache purged

--- a/src/server/hubspot_uninstall.test.ts
+++ b/src/server/hubspot_uninstall.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+vi.mock('@clerk/express', () => ({
+  requireAuth: () => (req: express.Request & { auth?: { userId: string } }, _res: express.Response, next: express.NextFunction) => {
+    req.auth = { userId: 'user_123' };
+    next();
+  },
+}));
+
+const fromMock = vi.fn();
+const deleteMock1 = vi.fn(() => ({ eq: vi.fn().mockResolvedValue({}) }));
+const deleteMock2 = vi.fn(() => ({ eq: vi.fn().mockResolvedValue({}) }));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    from: fromMock,
+  })),
+}));
+
+let hubspotUninstallHandler: typeof import('./hubspot_uninstall').hubspotUninstallHandler;
+
+beforeEach(async () => {
+  fromMock.mockClear();
+  deleteMock1.mockClear();
+  deleteMock2.mockClear();
+  fromMock
+    .mockImplementationOnce(() => ({ delete: deleteMock1 }))
+    .mockImplementationOnce(() => ({ delete: deleteMock2 }));
+  vi.resetModules();
+  ({ hubspotUninstallHandler } = await import('./hubspot_uninstall'));
+});
+
+describe('hubspotUninstallHandler', () => {
+  it('purges tokens and contacts for authed user', async () => {
+    const app = express();
+    app.post('/', ...hubspotUninstallHandler);
+
+    const res = await request(app).post('/');
+
+    expect(res.status).toBe(204);
+    expect(fromMock).toHaveBeenNthCalledWith(1, 'hubspot_tokens');
+    expect(fromMock).toHaveBeenNthCalledWith(2, 'hubspot_contacts_cache');
+  });
+});

--- a/src/server/hubspot_uninstall.ts
+++ b/src/server/hubspot_uninstall.ts
@@ -1,0 +1,23 @@
+import type { Request } from "express";
+import { RequestHandler } from 'express';
+import { requireAuth } from '@clerk/express';
+import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config';
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+interface AuthedRequest extends Request {
+  auth: { userId: string };
+}
+
+export const hubspotUninstallHandler: RequestHandler[] = [
+  requireAuth(),
+  async (req, res) => {
+    const portalId = (req as AuthedRequest).auth.userId;
+    await supabase.from('hubspot_tokens').delete().eq('portal_id', portalId);
+    await supabase.from('hubspot_contacts_cache').delete().eq('portal_id', portalId);
+    res.status(204).end();
+  },
+];
+
+export default hubspotUninstallHandler;

--- a/supabase/functions/hubspot_uninstall.ts
+++ b/supabase/functions/hubspot_uninstall.ts
@@ -1,0 +1,23 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from '../src/integrations/supabase/types';
+import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from '../src/server/config.ts';
+
+export async function hubspotUninstall(request: Request): Promise<Response> {
+  const auth = request.headers.get('Authorization') || '';
+  const sb = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    global: { headers: { Authorization: auth } },
+  });
+  const { data: { user } } = await sb.auth.getUser();
+  if (!user) return new Response('Unauthorized', { status: 401 });
+
+  await sb.from('hubspot_tokens').delete().eq('portal_id', user.id);
+  await sb.from('hubspot_contacts_cache').delete().eq('portal_id', user.id);
+
+  return new Response(null, { status: 204 });
+}
+
+if (typeof Deno !== 'undefined') {
+  const { serve } = await import('https://deno.land/std@0.205.0/http/server.ts');
+  serve(hubspotUninstall);
+}
+


### PR DESCRIPTION
## Summary
- add webhook to purge tokens and cached contacts
- document uninstall handler in API spec
- check off security task for uninstall cleanup
- cover uninstall webhook with tests

## Testing
- `npx vitest run`
- `npm run lint` *(fails: 27 problems)*
- `NODE_OPTIONS=--experimental-vm-modules npx jest --runTestsByPath src/server/search_contacts.test.ts` *(fails: ReferenceError: exports is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_6857459afcb88323aceabf31e18c48e9