### PR TITLE
Add Clerk profile and logout components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import Dashboard from "./pages/Dashboard";
+import Profile from "./pages/Profile";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -19,6 +20,7 @@ const App = () => (
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/profile" element={<Profile />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/dashboard/ProfileMenu.tsx
+++ b/src/components/dashboard/ProfileMenu.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { User, LogOut } from 'lucide-react';
+import { SignedIn, SignOutButton } from '@clerk/clerk-react';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator
+} from '@/components/ui/dropdown-menu';
+import { Button } from '@/components/ui/button';
+
+const ProfileMenu = () => (
+  <SignedIn>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="rounded-full border border-gray-200"
+          aria-label="Open profile menu"
+        >
+          <User className="w-5 h-5 text-slate-gray" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="bg-white text-slate-gray">
+        <DropdownMenuItem asChild>
+          <a href="/profile" className="flex items-center gap-2 w-full">
+            <User className="w-4 h-4" />
+            Profile
+          </a>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <SignOutButton>
+            <button className="flex items-center gap-2 w-full">
+              <LogOut className="w-4 h-4" />
+              Log Out
+            </button>
+          </SignOutButton>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  </SignedIn>
+);
+
+export default ProfileMenu;

--- a/src/components/dashboard/QuickSelectHeader.tsx
+++ b/src/components/dashboard/QuickSelectHeader.tsx
@@ -8,6 +8,7 @@ import { SidebarTrigger, useSidebar } from '@/components/ui/sidebar';
 import { headerVariants } from '@/lib/animations';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { Button } from '@/components/ui/button';
+import ProfileMenu from './ProfileMenu';
 
 const QuickSelectHeader = () => {
   const [selectedEntity, setSelectedEntity] = useState(null);
@@ -56,6 +57,7 @@ const QuickSelectHeader = () => {
             New Deck
           </ActionButton>
         )}
+        <ProfileMenu />
       </div>
     </motion.header>
   );

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { SignedIn, SignedOut, RedirectToSignIn, UserProfile } from '@clerk/clerk-react';
+
+const Profile = () => (
+  <>
+    <SignedOut>
+      <RedirectToSignIn />
+    </SignedOut>
+    <SignedIn>
+      <div className="min-h-screen bg-ice-white flex justify-center py-12">
+        <UserProfile />
+      </div>
+    </SignedIn>
+  </>
+);
+
+export default Profile;


### PR DESCRIPTION
## Summary
- create `ProfileMenu` dropdown with a log-out button
- add profile page wrapped in Clerk's `UserProfile` component
- link the profile page and menu in `QuickSelectHeader`
- register new profile route in `App`

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_685eaefd3040832383ab67c637dec7f5