### PR TITLE
Add Clerk profile menu with logout

### DIFF
--- a/src/components/auth/ProfileMenu.tsx
+++ b/src/components/auth/ProfileMenu.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { SignOutButton, useUser } from '@clerk/clerk-react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator
+} from '@/components/ui/dropdown-menu';
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
+
+const ProfileMenu = () => {
+  const { user } = useUser();
+  if (!user) return null;
+
+  const initials = user.firstName?.charAt(0) ?? 'U';
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className="h-10 w-10 hover:bg-gray-100">
+          <Avatar className="w-8 h-8">
+            <AvatarImage src={user.imageUrl} alt={user.fullName ?? 'User'} />
+            <AvatarFallback className="bg-electric-indigo text-ice-white">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="bg-white border border-gray-200 w-56">
+        <div className="px-3 py-2 text-sm">
+          <p className="font-medium text-slate-gray">{user.fullName}</p>
+          <p className="text-gray-600">{user.primaryEmailAddress?.emailAddress}</p>
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <SignOutButton>
+            <button className="w-full text-left text-slate-gray">Log Out</button>
+          </SignOutButton>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default ProfileMenu;

--- a/src/components/auth/UserProfileCard.tsx
+++ b/src/components/auth/UserProfileCard.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useUser } from '@clerk/clerk-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
+
+const UserProfileCard = () => {
+  const { user } = useUser();
+  if (!user) return null;
+
+  const initials = user.firstName?.charAt(0) ?? 'U';
+
+  return (
+    <Card className="bg-white border border-gray-200">
+      <CardContent className="p-6 flex items-center gap-4">
+        <Avatar className="w-14 h-14">
+          <AvatarImage src={user.imageUrl} alt={user.fullName ?? 'User'} />
+          <AvatarFallback className="bg-electric-indigo text-ice-white">
+            {initials}
+          </AvatarFallback>
+        </Avatar>
+        <div className="space-y-1">
+          <p className="text-lg font-medium text-slate-gray">{user.fullName}</p>
+          <p className="text-sm text-gray-600">{user.primaryEmailAddress?.emailAddress}</p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default UserProfileCard;

--- a/src/components/dashboard/QuickSelectHeader.tsx
+++ b/src/components/dashboard/QuickSelectHeader.tsx
@@ -8,6 +8,7 @@ import { SidebarTrigger, useSidebar } from '@/components/ui/sidebar';
 import { headerVariants } from '@/lib/animations';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { Button } from '@/components/ui/button';
+import ProfileMenu from '@/components/auth/ProfileMenu';
 
 const QuickSelectHeader = () => {
   const [selectedEntity, setSelectedEntity] = useState(null);
@@ -56,6 +57,8 @@ const QuickSelectHeader = () => {
             New Deck
           </ActionButton>
         )}
+
+        <ProfileMenu />
       </div>
     </motion.header>
   );


### PR DESCRIPTION
## Summary
- add `ProfileMenu` dropdown with Clerk sign out support
- show a simple `UserProfileCard` with user details
- include profile menu in the dashboard header

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and prefer-const)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685ef9e8eba0832382ef5912d12ed110