### PR TITLE
Add profile page and route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import Dashboard from "./pages/Dashboard";
+import Profile from "./pages/Profile";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -19,6 +20,7 @@ const App = () => (
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/profile" element={<Profile />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/auth/ProfileMenu.tsx
+++ b/src/components/auth/ProfileMenu.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { SignOutButton, useUser } from '@clerk/clerk-react';
+import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -19,7 +20,7 @@ const ProfileMenu = () => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="h-10 w-10 hover:bg-gray-100">
+        <Button variant="ghost" size="icon" className="h-10 w-10 hover:bg-gray-50">
           <Avatar className="w-8 h-8">
             <AvatarImage src={user.imageUrl} alt={user.fullName ?? 'User'} />
             <AvatarFallback className="bg-electric-indigo text-ice-white">
@@ -34,6 +35,11 @@ const ProfileMenu = () => {
           <p className="text-gray-600">{user.primaryEmailAddress?.emailAddress}</p>
         </div>
         <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link to="/profile" className="w-full text-slate-gray hover:bg-gray-50">
+            Profile
+          </Link>
+        </DropdownMenuItem>
         <DropdownMenuItem asChild>
           <SignOutButton>
             <button className="w-full text-left text-slate-gray">Log Out</button>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { SignedIn, SignedOut, RedirectToSignIn, UserProfile } from '@clerk/clerk-react';
+
+const Profile = () => (
+  <>
+    <SignedOut>
+      <RedirectToSignIn />
+    </SignedOut>
+    <SignedIn>
+      <div className="min-h-screen bg-ice-white flex justify-center py-10">
+        <UserProfile />
+      </div>
+    </SignedIn>
+  </>
+);
+
+export default Profile;


### PR DESCRIPTION
## Summary
- create Profile page
- register `/profile` route
- link to profile page from dropdown menu
- fix menu hover color to use brand-approved gray

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_685f2ed58d848323834438b7989a7b52