### PR TITLE
Include root-level tests

### DIFF
--- a/supabase/functions/hubspot_fetch_contacts.ts
+++ b/supabase/functions/hubspot_fetch_contacts.ts
@@ -1,3 +1,3 @@
-import { handleRequest } from '../src/server/hubspot_fetch_contacts.ts'
+import { handleRequest } from '../../src/server/hubspot_fetch_contacts.ts'
 
 Deno.serve(handleRequest)

--- a/supabase/functions/hubspot_oauth_callback.ts
+++ b/supabase/functions/hubspot_oauth_callback.ts
@@ -1,11 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
-import type { Database } from '../src/integrations/supabase/types';
+import type { Database } from '../../src/integrations/supabase/types';
 import {
   HUBSPOT_CLIENT_ID,
   HUBSPOT_CLIENT_SECRET,
   SUPABASE_URL,
   SUPABASE_SERVICE_ROLE_KEY,
-} from '../src/server/config.ts';
+} from '../../src/server/config.ts';
 
 const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig(({ mode }) => ({
     environment: "jsdom",
     globals: true,
     setupFiles: "./src/setupTests.ts",
-    include: ["src/**/*.{test,spec}.{js,ts,jsx,tsx}"],
+    include: ["**/*.{test,spec}.{js,ts,jsx,tsx}"],
     exclude: ["node_modules/**"],
   },
 }));


### PR DESCRIPTION
## Summary
- allow vitest to discover tests in repo root
- fix relative paths for supabase functions

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_685f37459cc883239bbd364fa7b2b731