### PR TITLE
Fix types and cleanup tests

### DIFF
--- a/hubspot_oauth_callback.test.ts
+++ b/hubspot_oauth_callback.test.ts
@@ -10,7 +10,7 @@ vi.mock('@supabase/supabase-js', () => ({
 }));
 
 const fetchMock = vi.fn();
-// @ts-ignore
+// @ts-expect-error assigning mock fetch
 global.fetch = fetchMock;
 
 describe('hubspotOAuthCallback', () => {

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -21,7 +21,7 @@ class ErrorBoundary extends Component<Props, State> {
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, errorInfo: any) {
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error('ErrorBoundary caught an error:', error, errorInfo);
   }
 

--- a/src/components/demo/SlideRenderer.tsx
+++ b/src/components/demo/SlideRenderer.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { DataScenario } from './types';
+import { DataScenario, ChartData } from './types';
 import TitleSlide from './slides/TitleSlide';
 import ChartSlide from './slides/ChartSlide';
 import InsightsSlide from './slides/InsightsSlide';
@@ -11,7 +11,7 @@ interface Slide {
   type: 'title' | 'chart' | 'insights' | 'summary';
   title: string;
   content?: string;
-  chartData?: any[];
+  chartData?: ChartData;
   insights?: string[];
 }
 

--- a/src/components/demo/slides/ChartSlide.tsx
+++ b/src/components/demo/slides/ChartSlide.tsx
@@ -1,12 +1,12 @@
 
 import React from 'react';
 import { motion } from 'framer-motion';
-import { DataScenario } from '../types';
+import { DataScenario, ChartData } from '../types';
 import { renderChart } from './chartRenderers';
 
 interface ChartSlideProps {
   title: string;
-  chartData?: any[];
+  chartData?: ChartData;
   scenario: DataScenario;
 }
 

--- a/src/components/demo/slides/chartRenderers.tsx
+++ b/src/components/demo/slides/chartRenderers.tsx
@@ -1,10 +1,10 @@
 
 import React from 'react';
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, LineChart, Line, AreaChart, Area } from 'recharts';
-import { DataScenario } from '../types';
+import { DataScenario, ChartData } from '../types';
 
 interface ChartRendererProps {
-  chartData: any[];
+  chartData: ChartData;
   scenario: DataScenario;
 }
 

--- a/src/components/demo/types.ts
+++ b/src/components/demo/types.ts
@@ -5,12 +5,14 @@ export interface DataScenario {
   description: string;
   icon: string;
   category: string;
-  sampleData: any[];
+  sampleData: ChartData;
   chartType: 'bar' | 'line' | 'pie' | 'area';
   insights: string[];
   templates: PresentationTemplate[];
   dataSource?: DataSource;
 }
+
+export type ChartData = Record<string, number | string>[];
 
 export interface DataSource {
   name: string;
@@ -25,7 +27,7 @@ export interface DataField {
   name: string;
   type: 'string' | 'number' | 'date' | 'boolean';
   description: string;
-  sampleValue: any;
+  sampleValue: string | number | boolean | Date;
 }
 
 export interface PresentationTemplate {
@@ -41,7 +43,7 @@ export interface Slide {
   type: 'title' | 'chart' | 'insights' | 'summary';
   title: string;
   content?: string;
-  chartData?: any[];
+  chartData?: ChartData;
   insights?: string[];
 }
 

--- a/src/integrations/hubspot/client.ts
+++ b/src/integrations/hubspot/client.ts
@@ -7,7 +7,7 @@ import crypto from 'crypto'
 
 export interface HubSpotContact {
   id: string
-  properties: Record<string, any>
+  properties: Record<string, unknown>
 }
 
 export interface HubSpotSearchResponse {
@@ -66,7 +66,7 @@ export async function postNote(
   { portal_id, hubspot_object_id, app_record_url }: PostNoteInput,
   sb: SupabaseClient<Database> = supabase,
   fetchFn: typeof fetch = fetch
-): Promise<{ noteId: string } | { error: any }> {
+): Promise<{ noteId: string } | { error: unknown }> {
   try {
     const accessToken = await ensureAccessToken(portal_id, sb, fetchFn)
     await rateLimiter.take(portal_id)
@@ -95,7 +95,7 @@ export async function postNote(
     }
     return { noteId: json.id }
   } catch (err) {
-    return { error: (err as Error).message }
+    return { error: err }
   }
 }
 

--- a/src/server/config.test.ts
+++ b/src/server/config.test.ts
@@ -8,11 +8,11 @@ async function loadConfig() {
 describe('config', () => {
   beforeEach(() => {
     vi.resetModules()
-    delete (global as any).Deno
+    delete (global as unknown as { Deno?: { env: { toObject(): Record<string, string> } } }).Deno
   })
 
   afterEach(() => {
-    delete (global as any).Deno
+    delete (global as unknown as { Deno?: { env: { toObject(): Record<string, string> } } }).Deno
   })
 
   it('reads values from process.env in Node', async () => {
@@ -25,7 +25,7 @@ describe('config', () => {
 
   it('prefers Deno.env when available', async () => {
     process.env.SUPABASE_URL = 'node-url'
-    ;(global as any).Deno = {
+    ;(global as unknown as { Deno?: { env: { toObject(): Record<string, string> } } }).Deno = {
       env: { toObject: () => ({ SUPABASE_URL: 'deno-url', SUPABASE_SERVICE_ROLE_KEY: 'deno-key' }) }
     }
     const cfg = await loadConfig()

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,8 +1,12 @@
 // Centralized environment configuration for both Node and Deno runtimes
 
+const maybeDeno = (globalThis as unknown as {
+  Deno?: { env: { toObject(): Record<string, string> } }
+}).Deno;
+
 const env: Record<string, string | undefined> =
-  typeof (globalThis as any).Deno !== 'undefined'
-    ? ((globalThis as any).Deno.env.toObject() as Record<string, string>)
+  typeof maybeDeno !== 'undefined'
+    ? maybeDeno.env.toObject()
     : process.env;
 
 export const HUBSPOT_CLIENT_ID = env.HUBSPOT_CLIENT_ID ?? '';

--- a/src/server/hubspot_fetch_contacts.test.ts
+++ b/src/server/hubspot_fetch_contacts.test.ts
@@ -39,7 +39,7 @@ describe('hubspotFetchContacts', () => {
       }),
     })
 
-    await hubspotFetchContacts('p1', undefined, undefined as any, fetchMock)
+    await hubspotFetchContacts('p1', undefined, undefined, fetchMock)
 
     expect(fetchMock).toHaveBeenCalled()
     expect(upsertCache).toHaveBeenCalled()

--- a/src/server/hubspot_fetch_contacts.ts
+++ b/src/server/hubspot_fetch_contacts.ts
@@ -8,7 +8,7 @@ const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 
 export interface HubSpotContact {
   id: string
-  properties: Record<string, any>
+  properties: Record<string, unknown>
 }
 
 export interface HubSpotSearchResponse {
@@ -24,7 +24,7 @@ export async function hubspotFetchContacts(
   const accessToken = await ensureAccessToken(portal_id, sb, fetchFn)
   await rateLimiter.take(portal_id)
 
-  const body: Record<string, any> = {
+  const body: Record<string, unknown> = {
     limit: 100,
     sorts: ['hs_lastmodifieddate'],
     properties: ['firstname', 'lastname', 'email', 'hs_lastmodifieddate'],

--- a/src/server/hubspot_webhook.test.ts
+++ b/src/server/hubspot_webhook.test.ts
@@ -25,7 +25,7 @@ vi.mock('@supabase/supabase-js', () => ({
           if (table === 'hubspot_tokens') return deleteTokensMock(field, val);
           if (table === 'hubspot_contacts_cache') return deleteCacheMock(field, val);
           if (table === 'hubspot_sync_cursors') return deleteCursorsMock(field, val);
-          return undefined as any;
+          return undefined;
         },
       }),
     }),

--- a/src/server/hubspot_webhook.ts
+++ b/src/server/hubspot_webhook.ts
@@ -41,7 +41,7 @@ export const hubspotWebhookHandler: RequestHandler[] = [
     const payload = req.body;
 
     const events = Array.isArray(payload) ? payload : [payload];
-    const uninstall = events.some((e: any) => e.subscriptionType === 'app.uninstalled');
+    const uninstall = events.some((e: Record<string, unknown>) => e.subscriptionType === 'app.uninstalled');
 
     if (uninstall) {
       // Handle cleanup operations with proper async/await

--- a/src/server/post_note.test.ts
+++ b/src/server/post_note.test.ts
@@ -15,7 +15,7 @@ vi.mock('@supabase/supabase-js', () => ({
   })),
 }));
 
-let fetchMock: any;
+let fetchMock: vi.Mock;
 
 beforeEach(() => {
   fetchMock = vi.fn();

--- a/src/server/post_note.ts
+++ b/src/server/post_note.ts
@@ -2,7 +2,7 @@ import { postNote as hubspotPostNote, PostNoteInput } from '../integrations/hubs
 
 export async function postNote(
   input: PostNoteInput,
-): Promise<{ noteId: string } | { error: any }> {
+): Promise<{ noteId: string } | { error: unknown }> {
   return hubspotPostNote(input)
 }
 

--- a/src/server/search_contacts.ts
+++ b/src/server/search_contacts.ts
@@ -11,7 +11,7 @@ import { searchContacts as hubspotSearch } from '../integrations/hubspot/client'
 
 export interface ContactRecord {
   id: string
-  properties: Record<string, any>
+  properties: Record<string, unknown>
 }
 
 
@@ -58,7 +58,7 @@ export async function searchContacts(
 ): Promise<ContactRecord[]> {
   const local = await searchLocal(portal_id, q, limit, sb)
   const seen = new Set(local.map(r => r.id))
-  let results = [...local]
+  const results = [...local]
   if (results.length < 5) {
     const remote = await searchRemote(portal_id, q, limit, sb, fetchFn)
     for (const r of remote) {


### PR DESCRIPTION
## Summary
- replace `@ts-ignore` with `@ts-expect-error`
- update React error info type
- add `ChartData` type and use it across demo components
- tighten HubSpot client and server types
- remove `any` casts in tests and config
- adjust Supabase function typing
- run lint and tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686007a9552083238967e3de8d0b1cb5