### PR TITLE
Fix post_note input and lint warnings

### DIFF
--- a/src/server/hubspot_fetch_contacts.ts
+++ b/src/server/hubspot_fetch_contacts.ts
@@ -64,7 +64,7 @@ export async function hubspotFetchContacts(
     const rows = results.map((r) => ({
       portal_id,
       id: r.id,
-      properties: r.properties as any, // Cast to Json type for Supabase
+      properties: r.properties as Database['public']['Tables']['hubspot_contacts_cache']['Insert']['properties'],
       updated_at: (r.properties.hs_lastmodifieddate as string) || new Date().toISOString(),
     }))
     await sb.from('hubspot_contacts_cache').upsert(rows)

--- a/src/server/post_note.test.ts
+++ b/src/server/post_note.test.ts
@@ -5,7 +5,7 @@ import { postNote } from './post_note'
 // Mock the HubSpot client
 vi.mock('../integrations/hubspot/client', () => ({
   postNote: vi.fn(async (input) => {
-    if (input.contactId === 'error') {
+    if (input.hubspot_object_id === 'error') {
       return { error: 'Test error' }
     }
     return { noteId: 'test-note-id' }
@@ -15,9 +15,9 @@ vi.mock('../integrations/hubspot/client', () => ({
 describe('postNote', () => {
   it('should return noteId on success', async () => {
     const result = await postNote({
-      contactId: 'test-contact-id',
-      noteBody: 'Test note',
-      portalId: 'test-portal',
+      portal_id: 'test-portal',
+      hubspot_object_id: 'test-contact-id',
+      app_record_url: 'http://example.com/app-record',
     })
 
     expect(result).toEqual({ noteId: 'test-note-id' })
@@ -25,9 +25,9 @@ describe('postNote', () => {
 
   it('should return error on failure', async () => {
     const result = await postNote({
-      contactId: 'error',
-      noteBody: 'Test note',
-      portalId: 'test-portal',
+      portal_id: 'test-portal',
+      hubspot_object_id: 'error',
+      app_record_url: 'http://example.com/app-record',
     })
 
     expect(result).toEqual({ error: 'Test error' })

--- a/src/server/search_contacts.ts
+++ b/src/server/search_contacts.ts
@@ -67,12 +67,14 @@ async function searchRemote(
   if (rows.length) {
     await sb
       .from('hubspot_contacts_cache')
-      .upsert(rows.map(r => ({ 
-        portal_id, 
-        id: r.id, 
-        properties: r.properties as any, // Cast to Json type for Supabase
-        updated_at: now 
-      })))
+      .upsert(
+        rows.map(r => ({
+          portal_id,
+          id: r.id,
+          properties: r.properties as Database['public']['Tables']['hubspot_contacts_cache']['Insert']['properties'],
+          updated_at: now,
+        }))
+      )
   }
   return rows.slice(0, limit)
 }


### PR DESCRIPTION
## Summary
- align `post_note.test` with updated `PostNoteInput` fields
- ensure contact caching uses typed `properties` instead of `any`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68600d3935f083239dc1e182de747459