### PR TITLE
Enable hero demo button scrolling

### DIFF
--- a/src/components/InteractiveDemo.tsx
+++ b/src/components/InteractiveDemo.tsx
@@ -38,7 +38,7 @@ const InteractiveDemo = () => {
   };
 
   return (
-    <section className="section-padding bg-gradient-to-br from-ice-white to-slate-50">
+    <section id="demo" className="section-padding bg-gradient-to-br from-ice-white to-slate-50">
       <div className="container mx-auto container-padding">
         <motion.div
           initial={{ opacity: 0, y: 30 }}

--- a/src/components/ModernHero.tsx
+++ b/src/components/ModernHero.tsx
@@ -7,6 +7,10 @@ import { Button } from './ui/button';
 import { containerVariants, itemVariants } from '../lib/variants';
 
 const ModernHero = () => {
+  const handleWatchDemo = () => {
+    document.getElementById('demo')?.scrollIntoView({ behavior: 'smooth' });
+  };
+
   return (
     <section className="min-h-screen flex items-center justify-center relative overflow-hidden bg-ice-white">
       {/* Background gradient */}
@@ -63,7 +67,7 @@ const ModernHero = () => {
             variants={itemVariants}
             className="flex justify-center mb-16"
           >
-            <Button variant="outline" className="btn-secondary">
+            <Button variant="outline" className="btn-secondary" onClick={handleWatchDemo}>
               Watch Demo
             </Button>
           </motion.div>


### PR DESCRIPTION
## Summary
- scroll to the interactive demo section when clicking **Watch Demo**
- give the demo section an `id` for linking

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6860117a6d3c832386de6294b82b216c