### PR TITLE
Fix invalid OpenAI model

### DIFF
--- a/supabase/functions/generate-slides/index.ts
+++ b/supabase/functions/generate-slides/index.ts
@@ -28,7 +28,7 @@ serve(async (req) => {
 
       try {
         const completion = await openai.chat.completions.create({
-          model: 'gpt-4.1-mini-2025-04-144',
+          model: 'gpt-4.1-mini',
           messages: [
             { role: 'system', content: 'Return a JSON array of slide objects with title, bullets[], images[]' },
             { role: 'user', content: `Prompt: ${prompt}\nSlides: ${count}` },


### PR DESCRIPTION
## Summary
- use the correct `gpt-4.1-mini` model in generate-slides function

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_68601192c65c83239ea1f192d48c82e7