### PR TITLE
Add deck listing via Supabase

### DIFF
--- a/src/components/dashboard/DeckList.tsx
+++ b/src/components/dashboard/DeckList.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { useDecks } from '@/hooks/useDecks';
+
+const DeckList = () => {
+  const { decks, loading } = useDecks();
+
+  return (
+    <Card className="border-gray-200 bg-white">
+      <CardContent className="p-4 space-y-2">
+        <h2 className="font-semibold text-slate-gray">Past Decks</h2>
+        {loading && <p className="text-sm text-gray-600">Loading...</p>}
+        {!loading && decks.length === 0 && (
+          <p className="text-sm text-gray-600">No decks found</p>
+        )}
+        <ul className="space-y-1">
+          {decks.map((deck) => (
+            <li key={deck.id} className="text-sm text-slate-gray">
+              {deck.prompt}
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default DeckList;

--- a/src/hooks/useDecks.ts
+++ b/src/hooks/useDecks.ts
@@ -1,0 +1,75 @@
+import { useState, useEffect } from 'react';
+import { useSupabaseClient } from './useSupabaseClient';
+
+export interface DeckSummary {
+  id: string;
+  prompt: string;
+  created_at: string;
+}
+
+export const useDecks = () => {
+  const supabase = useSupabaseClient();
+  const [decks, setDecks] = useState<DeckSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDecks = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const { data, error: fetchError } = await supabase
+        .from('decks')
+        .select('id, prompt, created_at')
+        .order('created_at', { ascending: false });
+
+      if (fetchError) {
+        throw fetchError;
+      }
+
+      setDecks(data || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+      console.error('Error fetching decks:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getSlides = async (deckId: string) => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const { data, error: fetchError } = await supabase
+        .from('decks')
+        .select('slide_json')
+        .eq('id', deckId)
+        .single();
+
+      if (fetchError) {
+        throw fetchError;
+      }
+
+      return data?.slide_json ?? null;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+      console.error('Error fetching deck slides:', err);
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchDecks();
+  }, []);
+
+  return {
+    decks,
+    loading,
+    error,
+    refetch: fetchDecks,
+    getSlides,
+  };
+};

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -9,6 +9,7 @@ import ContextPane from '@/components/dashboard/ContextPane';
 import DeckGallery from '@/components/dashboard/DeckGallery';
 import ActivityPanel from '@/components/dashboard/ActivityPanel';
 import IntegrationsPanel from '@/components/dashboard/IntegrationsPanel';
+import DeckList from '@/components/dashboard/DeckList';
 import FloatingActionButton from '@/components/ui/floating-action-button';
 import ErrorBoundary from '@/components/ErrorBoundary';
 
@@ -52,6 +53,9 @@ const Dashboard = () => {
                 </ErrorBoundary>
                 <ErrorBoundary fallback={<div className="p-4 bg-gray-100">Integration Error</div>}>
                   <IntegrationsPanel />
+                </ErrorBoundary>
+                <ErrorBoundary fallback={<div className="p-4 bg-gray-100">Decks Error</div>}>
+                  <DeckList />
                 </ErrorBoundary>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add `useDecks` hook to query Supabase for saved decks and slides
- show past decks in new `DeckList` component
- display the deck list on the Dashboard page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68601679a2a88323977a7d7c965844e4