### PR TITLE
Add grid overlay toggle for slide editor

### DIFF
--- a/src/components/DeckEditor.tsx
+++ b/src/components/DeckEditor.tsx
@@ -1,5 +1,6 @@
-import React, { useRef, useEffect } from 'react'
+import React, { useRef, useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
 
 interface DeckEditorProps {
   initialSlides: unknown
@@ -8,6 +9,7 @@ interface DeckEditorProps {
 
 const DeckEditor = ({ initialSlides, onApply }: DeckEditorProps) => {
   const editorRef = useRef<HTMLDeckgoEditorElement | null>(null)
+  const [showGrid, setShowGrid] = useState(false)
 
   // Load the DeckDeckGo editor script once
   useEffect(() => {
@@ -58,9 +60,22 @@ const DeckEditor = ({ initialSlides, onApply }: DeckEditorProps) => {
 
   return (
     <div className="space-y-4">
-      {/* The DeckDeckGo editor web component */}
-      <deckgo-editor ref={editorRef}></deckgo-editor>
-      <Button onClick={handleApply}>Apply Edits</Button>
+      <div className="flex items-center gap-4">
+        <Switch
+          id="show-grid"
+          checked={showGrid}
+          onCheckedChange={setShowGrid}
+        />
+        <label htmlFor="show-grid" className="text-sm text-slate-gray">
+          Show Grid
+        </label>
+        <Button onClick={handleApply}>Apply Edits</Button>
+      </div>
+      <div className="relative">
+        {/* The DeckDeckGo editor web component */}
+        <deckgo-editor ref={editorRef}></deckgo-editor>
+        {showGrid && <div className="grid-overlay pointer-events-none absolute inset-0" />}
+      </div>
     </div>
   )
 }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -48,3 +48,18 @@
 .will-change-opacity {
   will-change: opacity;
 }
+
+/* Grid overlay for the slide editor */
+.grid-overlay {
+  background-image: linear-gradient(
+      to right,
+      rgba(58, 61, 77, 0.15) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      to bottom,
+      rgba(58, 61, 77, 0.15) 1px,
+      transparent 1px
+    );
+  background-size: 20px 20px;
+}


### PR DESCRIPTION
## Summary
- add switch to DeckEditor toolbar to toggle grid overlay
- show overlay using brand-compliant grid styling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68606f41b9a483239cc8284170de6644