### PR TITLE
bundle reveal.js locally

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,11 +22,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Montserrat:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
-    <!-- Reveal.js -->
-    <link rel="stylesheet" href="https://unpkg.com/reveal.js/dist/reveal.css">
-    <link rel="stylesheet" href="https://unpkg.com/reveal.js/dist/theme/black.css">
-    <script src="https://unpkg.com/reveal.js/dist/reveal.js"></script>
-    <script src="https://unpkg.com/reveal.js/plugin/print-pdf/print-pdf.js"></script>
   </head>
 
   <body>

--- a/src/components/SlideDeck.tsx
+++ b/src/components/SlideDeck.tsx
@@ -1,13 +1,7 @@
 import React, { useEffect, useRef } from 'react'
-
-declare global {
-  interface Window {
-    Reveal: {
-      initialize: (options: unknown) => void
-    }
-    RevealPrintPDF: unknown
-  }
-}
+import Reveal from 'reveal.js'
+import 'reveal.js/dist/reveal.css'
+import 'reveal.js/dist/theme/black.css'
 
 export interface SlideImage {
   src: string
@@ -31,12 +25,18 @@ const SlideDeck = ({ slides }: SlideDeckProps) => {
   const deckRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    if (!window.Reveal || !window.RevealPrintPDF) return
-    window.Reveal.initialize({
-      plugins: [window.RevealPrintPDF],
+    if (!deckRef.current) return
+
+    const deck = new Reveal(deckRef.current, {
       pdfSeparateFragments: true,
       pdfMaxPagesPerSlide: 1,
     })
+
+    deck.initialize()
+
+    return () => {
+      deck.destroy()
+    }
   }, [])
 
   return (


### PR DESCRIPTION
## Summary
- remove Reveal CDN includes in `index.html`
- import Reveal.js and theme locally in `SlideDeck`
- initialize and destroy Reveal instance in the component

## Testing
- `npm run lint -- --fix`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68607d17b6388323a296a57694cf983e