### PR TITLE
Fix router for Lovable preview

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, HashRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import Dashboard from "./pages/Dashboard";
 import Profile from "./pages/Profile";
@@ -12,12 +12,18 @@ import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
 
+const isPreview =
+  typeof window !== 'undefined' &&
+  (window.location.hostname.includes('lovableproject.com') ||
+    window.location.hostname.includes('lovable.app'));
+const Router = isPreview ? HashRouter : BrowserRouter;
+
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
+      <Router>
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/dashboard" element={<Dashboard />} />
@@ -26,7 +32,7 @@ const App = () => (
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>
-      </BrowserRouter>
+      </Router>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -18,7 +18,8 @@ const Dashboard = () => {
   const { isSignedIn } = useAuth();
   
   // Development mode bypass - check if we're in Lovable preview environment
-  const isDevelopment = window.location.hostname.includes('lovableproject.com') || 
+  const isDevelopment = window.location.hostname.includes('lovableproject.com') ||
+                       window.location.hostname.includes('lovable.app') ||
                        window.location.hostname === 'localhost' ||
                        process.env.NODE_ENV === 'development';
 


### PR DESCRIPTION
## Summary
- detect Lovable preview domain
- switch to HashRouter in preview to avoid 404s
- broaden domain check to include `.lovable.app`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68609aad69fc8323865a8c7d39e8ff39