### PR TITLE
Fix background fallbacks

### DIFF
--- a/src/components/demo/utils/slideGenerator.ts
+++ b/src/components/demo/utils/slideGenerator.ts
@@ -1,12 +1,12 @@
 
-import { DataScenario } from '../types';
+import { DataScenario, ChartData } from '../types';
 
 export interface GeneratedSlide {
   id: string;
   type: 'title' | 'chart' | 'insights' | 'summary';
   title: string;
   content?: string;
-  chartData?: any;
+  chartData?: ChartData;
   insights?: string[];
 }
 

--- a/src/components/shared/AnimatedContainer.tsx
+++ b/src/components/shared/AnimatedContainer.tsx
@@ -17,7 +17,10 @@ const AnimatedContainer = ({
 }: AnimatedContainerProps) => {
   return (
     <motion.div
-      className={cn("grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6", className)}
+      className={cn(
+        "grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6 bg-background",
+        className
+      )}
       variants={variants}
       initial="hidden"
       animate="visible"

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -40,7 +40,7 @@ const Dashboard = () => {
               <QuickSelectHeader />
             </ErrorBoundary>
             
-            <div className="flex-1 p-6 space-y-6">
+            <div className="flex-1 p-6 space-y-6 bg-background">
               <div className="flex flex-col lg:flex-row gap-6">
                 <div className="flex-1 mobile-stack">
                   <ErrorBoundary fallback={<div className="p-4 bg-gray-100">Context Error</div>}>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -52,7 +52,7 @@
 
   body {
     @apply bg-ice-white text-slate-gray font-sans;
-    background: #FAFAFB;
+    background: rgb(var(--background, 250 250 251));
     min-height: 100vh;
     line-height: 1.6;
   }


### PR DESCRIPTION
## Summary
- ensure body background uses CSS variable fallback
- give AnimatedContainer an explicit background
- explicitly color Dashboard content container
- type `chartData` in slideGenerator

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6860b10f5a388323b98ac5ee26527287