### PR TITLE
Fix background color variables

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -516,7 +516,7 @@ const sidebarMenuButtonVariants = cva(
       variant: {
         default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
         outline:
-          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+          "bg-background shadow-[0_0_0_1px_rgb(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_rgb(var(--sidebar-accent))]",
       },
       size: {
         default: "h-8 text-sm",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,50 +20,50 @@ export default {
 			}
 		},
 		extend: {
-			colors: {
-				border: 'hsl(var(--border))',
-				input: 'hsl(var(--input))',
-				ring: 'hsl(var(--ring))',
-				background: 'hsl(var(--background))',
-				foreground: 'hsl(var(--foreground))',
-				primary: {
-					DEFAULT: 'hsl(var(--primary))',
-					foreground: 'hsl(var(--primary-foreground))'
-				},
-				secondary: {
-					DEFAULT: 'hsl(var(--secondary))',
-					foreground: 'hsl(var(--secondary-foreground))'
-				},
-				destructive: {
-					DEFAULT: 'hsl(var(--destructive))',
-					foreground: 'hsl(var(--destructive-foreground))'
-				},
-				muted: {
-					DEFAULT: 'hsl(var(--muted))',
-					foreground: 'hsl(var(--muted-foreground))'
-				},
-				accent: {
-					DEFAULT: 'hsl(var(--accent))',
-					foreground: 'hsl(var(--accent-foreground))'
-				},
-				popover: {
-					DEFAULT: 'hsl(var(--popover))',
-					foreground: 'hsl(var(--popover-foreground))'
-				},
-				card: {
-					DEFAULT: 'hsl(var(--card))',
-					foreground: 'hsl(var(--card-foreground))'
-				},
-				sidebar: {
-					DEFAULT: 'hsl(var(--sidebar-background))',
-					foreground: 'hsl(var(--sidebar-foreground))',
-					primary: 'hsl(var(--sidebar-primary))',
-					'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
-					accent: 'hsl(var(--sidebar-accent))',
-					'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
-					border: 'hsl(var(--sidebar-border))',
-					ring: 'hsl(var(--sidebar-ring))'
-				},
+                        colors: {
+                                border: 'rgb(var(--border))',
+                                input: 'rgb(var(--input))',
+                                ring: 'rgb(var(--ring))',
+                                background: 'rgb(var(--background))',
+                                foreground: 'rgb(var(--foreground))',
+                                primary: {
+                                        DEFAULT: 'rgb(var(--primary))',
+                                        foreground: 'rgb(var(--primary-foreground))'
+                                },
+                                secondary: {
+                                        DEFAULT: 'rgb(var(--secondary))',
+                                        foreground: 'rgb(var(--secondary-foreground))'
+                                },
+                                destructive: {
+                                        DEFAULT: 'rgb(var(--destructive))',
+                                        foreground: 'rgb(var(--destructive-foreground))'
+                                },
+                                muted: {
+                                        DEFAULT: 'rgb(var(--muted))',
+                                        foreground: 'rgb(var(--muted-foreground))'
+                                },
+                                accent: {
+                                        DEFAULT: 'rgb(var(--accent))',
+                                        foreground: 'rgb(var(--accent-foreground))'
+                                },
+                                popover: {
+                                        DEFAULT: 'rgb(var(--popover))',
+                                        foreground: 'rgb(var(--popover-foreground))'
+                                },
+                                card: {
+                                        DEFAULT: 'rgb(var(--card))',
+                                        foreground: 'rgb(var(--card-foreground))'
+                                },
+                                sidebar: {
+                                        DEFAULT: 'rgb(var(--sidebar-background))',
+                                        foreground: 'rgb(var(--sidebar-foreground))',
+                                        primary: 'rgb(var(--sidebar-primary))',
+                                        'primary-foreground': 'rgb(var(--sidebar-primary-foreground))',
+                                        accent: 'rgb(var(--sidebar-accent))',
+                                        'accent-foreground': 'rgb(var(--sidebar-accent-foreground))',
+                                        border: 'rgb(var(--sidebar-border))',
+                                        ring: 'rgb(var(--sidebar-ring))'
+                                },
 				// Brand colors
 				'electric-indigo': '#5A2EFF',
 				'slate-gray': '#3A3D4D',


### PR DESCRIPTION
## Summary
- ensure Tailwind uses rgb() for custom color variables
- fix sidebar outline shadow to use rgb variables

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6860b40caf04832384b533f981a2394c