### PR TITLE
Improve HubSpot OAuth error handling

### DIFF
--- a/hubspot_oauth_callback.test.ts
+++ b/hubspot_oauth_callback.test.ts
@@ -48,6 +48,6 @@ describe('hubspotOAuthCallback', () => {
     const res = await hubspotOAuthCallback(new Request('https://example.com/cb?code=123&state=me'));
     expect(res.status).toBe(500);
     const body = await res.text();
-    expect(body).toContain('fail');
+    expect(body).toContain('HubSpot token exchange failed');
   });
 });

--- a/supabase/functions/hubspot_oauth_callback.ts
+++ b/supabase/functions/hubspot_oauth_callback.ts
@@ -41,7 +41,8 @@ export async function hubspotOAuthCallback(request: Request): Promise<Response> 
 
     if (!tokenRes.ok) {
       const text = await tokenRes.text();
-      throw new Error(`HubSpot token exchange failed: ${text}`);
+      console.error('HubSpot token exchange failed:', text);
+      throw new Error('HubSpot token exchange failed');
     }
 
     const token = await tokenRes.json() as {
@@ -71,8 +72,8 @@ export async function hubspotOAuthCallback(request: Request): Promise<Response> 
       headers: { Location: '/dashboard' },
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    return new Response(htmlError(message), {
+    console.error('OAuth callback error:', err);
+    return new Response(htmlError('HubSpot token exchange failed'), {
       status: 500,
       headers: { 'Content-Type': 'text/html' },
     });


### PR DESCRIPTION
## Summary
- log detailed token exchange failures server-side
- respond with a generic message during HubSpot OAuth callback
- update tests for generic failure message

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68616391eac883238dc973691e3da668