### PR TITLE
Move HubSpot client id behind edge function

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,15 +238,14 @@ This landing page showcases modern web animation techniques while maintaining ex
 Create a `.env` file in the project root and provide the following variables:
 
 ```bash
-VITE_HUBSPOT_CLIENT_ID=<your public OAuth id>
-HUBSPOT_CLIENT_ID=<your private OAuth id>
+HUBSPOT_CLIENT_ID=<your HubSpot OAuth id>
 HUBSPOT_CLIENT_SECRET=<your HubSpot secret>
 HUBSPOT_APP_SECRET=<webhook signature secret>
 SUPABASE_URL=<your Supabase project URL>
 SUPABASE_SERVICE_ROLE_KEY=<service role key>
 ```
 
-The React dashboard reads `VITE_HUBSPOT_CLIENT_ID` when initiating OAuth. The server and Edge Function code use the remaining variables via `src/server/config.ts`.
+The React dashboard fetches the client id from the `hubspot_client_id` edge function before initiating OAuth. Server code reads all variables via `src/server/config.ts`.
 
 ## Supabase CLI Setup
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -49,17 +49,23 @@ paths:
       responses:
         "200":
           description: Created note identifier
-  /hubspot_oauth_callback:
-    get:
-      description: OAuth callback endpoint for HubSpot authorization
-      responses:
-        "200":
-          description: Authorization successful
-  /hubspot_fetch_contacts:
-    get:
-      description: Fetch contacts from HubSpot and populate the cache
-      parameters:
-        - in: query
+    /hubspot_oauth_callback:
+      get:
+        description: OAuth callback endpoint for HubSpot authorization
+        responses:
+          "200":
+            description: Authorization successful
+    /hubspot_client_id:
+      get:
+        description: Return the HubSpot OAuth client id
+        responses:
+          "200":
+            description: Object with client_id
+    /hubspot_fetch_contacts:
+      get:
+        description: Fetch contacts from HubSpot and populate the cache
+        parameters:
+          - in: query
           name: portal_id
           required: true
           schema:

--- a/src/components/dashboard/HubSpotConnection.tsx
+++ b/src/components/dashboard/HubSpotConnection.tsx
@@ -22,13 +22,19 @@ const HubSpotConnection = () => {
       // Store state in localStorage for validation after redirect
       localStorage.setItem('hubspot_oauth_state', state);
       
+      // Fetch the client id from the Supabase edge function
+      const idRes = await fetch('/api/hubspot_client_id');
+      if (!idRes.ok) {
+        throw new Error('Failed to load HubSpot client id');
+      }
+      const { client_id } = await idRes.json();
+      if (!client_id) {
+        throw new Error('Missing HubSpot client id');
+      }
+
       // Construct HubSpot OAuth URL
       const hubspotAuthUrl = new URL('https://app.hubspot.com/oauth/authorize');
-      const clientId = import.meta.env.VITE_HUBSPOT_CLIENT_ID;
-      if (!clientId) {
-        throw new Error('Missing VITE_HUBSPOT_CLIENT_ID env');
-      }
-      hubspotAuthUrl.searchParams.set('client_id', clientId);
+      hubspotAuthUrl.searchParams.set('client_id', client_id);
       hubspotAuthUrl.searchParams.set('scope', 'contacts');
       hubspotAuthUrl.searchParams.set('redirect_uri', `${window.location.origin}/api/hubspot_oauth_callback`);
       hubspotAuthUrl.searchParams.set('state', state);

--- a/supabase/functions/hubspot_client_id.ts
+++ b/supabase/functions/hubspot_client_id.ts
@@ -1,0 +1,15 @@
+import { HUBSPOT_CLIENT_ID } from '../../src/server/config.ts'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+Deno.serve((req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders })
+  }
+  return new Response(JSON.stringify({ client_id: HUBSPOT_CLIENT_ID }), {
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  })
+})


### PR DESCRIPTION
## Summary
- add `hubspot_client_id` Supabase edge function
- fetch client id from the new function in `HubSpotConnection`
- document the new approach and update environment variable section
- expose `/hubspot_client_id` endpoint in OpenAPI spec

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68616201e7ac832383fcb6b60cdee1f3