### PR TITLE
Remove HubSpot OAuth state storage

### DIFF
--- a/src/components/dashboard/HubSpotConnection.tsx
+++ b/src/components/dashboard/HubSpotConnection.tsx
@@ -23,8 +23,6 @@ const HubSpotConnection = () => {
       // Generate a unique state parameter for OAuth security
       const state = crypto.randomUUID();
 
-      // Store state in localStorage for validation after redirect
-      localStorage.setItem('hubspot_oauth_state', state);
 
       if (!user) {
         throw new Error('User not authenticated');


### PR DESCRIPTION
## Summary
- remove localStorage usage for HubSpot OAuth state

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6861673aafac8323bcfe562493b40c6d