### PR TITLE
Read HubSpot id from Supabase secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,11 +238,16 @@ This landing page showcases modern web animation techniques while maintaining ex
 Create a `.env` file in the project root and provide the following variables:
 
 ```bash
-HUBSPOT_CLIENT_ID=<your HubSpot OAuth id>
 HUBSPOT_CLIENT_SECRET=<your HubSpot secret>
 HUBSPOT_APP_SECRET=<webhook signature secret>
 SUPABASE_URL=<your Supabase project URL>
 SUPABASE_SERVICE_ROLE_KEY=<service role key>
+```
+
+Store the client id for the edge functions using Supabase secrets:
+
+```bash
+supabase secrets set HUBSPOT_CLIENT_ID=<your HubSpot OAuth id>
 ```
 
 The React dashboard fetches the client id from the `hubspot_client_id` edge function before initiating OAuth. Server code reads all variables via `src/server/config.ts`.

--- a/docs/INTEGRATION_STRUCTURE.md
+++ b/docs/INTEGRATION_STRUCTURE.md
@@ -8,7 +8,8 @@ The reusable handlers live in `src/server/` and are imported by thin wrappers un
 
 The HubSpot client relies on the following variables which are read in `src/server/config.ts`:
 
-- `HUBSPOT_CLIENT_ID` – OAuth client id of the HubSpot app.
+- `HUBSPOT_CLIENT_ID` – OAuth client id of the HubSpot app. When deploying
+  edge functions, supply this value using `supabase secrets set`.
 - `HUBSPOT_CLIENT_SECRET` – OAuth client secret used when exchanging and refreshing tokens.
 - `HUBSPOT_APP_SECRET` – Secret used to validate webhook signatures.
 - `SUPABASE_URL` – Base URL of the Supabase instance.

--- a/supabase/functions/hubspot_client_id.ts
+++ b/supabase/functions/hubspot_client_id.ts
@@ -1,4 +1,6 @@
-import { HUBSPOT_CLIENT_ID } from '../../src/server/config.ts'
+// The client id is read from Supabase Edge Function secrets at runtime
+
+const HUBSPOT_CLIENT_ID = Deno.env.get('HUBSPOT_CLIENT_ID') || ''
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',


### PR DESCRIPTION
## Summary
- load HUBSPOT_CLIENT_ID directly from `Deno.env` in the edge function
- document storing the secret via `supabase secrets set`
- mention secret usage in integration docs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68616952d70483238ea17da6e28bbb9d