### PR TITLE
Implement Clerk profile tabs

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   SignedIn,
   SignedOut,
@@ -11,41 +12,71 @@ import QuickSelectHeader from '@/components/dashboard/QuickSelectHeader';
 import LeftNav from '@/components/dashboard/LeftNav';
 import ErrorBoundary from '@/components/ErrorBoundary';
 
-const ProfileContent = () => (
-  <div className="min-h-screen bg-ice-white">
-    <SidebarProvider>
-      <div className="flex min-h-screen w-full">
-        <ErrorBoundary fallback={<div className="w-64 bg-gray-100 p-4">Navigation Error</div>}>
-          <LeftNav />
-        </ErrorBoundary>
+const navItems = [
+  { label: 'Account', value: 'account' },
+  { label: 'Security', value: 'security' }
+];
 
-        <SidebarInset className="flex-1">
-          <ErrorBoundary fallback={<div className="h-16 bg-gray-100 p-4">Header Error</div>}>
-            <QuickSelectHeader />
+const ProfileContent = () => {
+  const [activeTab, setActiveTab] = React.useState('account');
+
+  return (
+    <div className="min-h-screen bg-ice-white">
+      <SidebarProvider>
+        <div className="flex min-h-screen w-full">
+          <ErrorBoundary fallback={<div className="w-64 bg-gray-100 p-4">Navigation Error</div>}>
+            <LeftNav />
           </ErrorBoundary>
 
-          <div className="flex justify-center p-6 bg-background">
-            <UserProfile
-              appearance={{
-                variables: {
-                  colorPrimary: brandColors['electric-indigo'],
-                  colorBackground: brandColors['ice-white'],
-                  colorText: brandColors['slate-gray'],
-                  colorTextSecondary: brandColors['gray-600'],
-                  fontFamily: 'Inter, sans-serif',
-                },
-                elements: {
-                  card: 'bg-white border border-gray-200',
-                  headerTitle: 'text-slate-gray',
-                },
-              }}
-            />
-          </div>
-        </SidebarInset>
-      </div>
-    </SidebarProvider>
-  </div>
-);
+          <SidebarInset className="flex-1">
+            <ErrorBoundary fallback={<div className="h-16 bg-gray-100 p-4">Header Error</div>}>
+              <QuickSelectHeader />
+            </ErrorBoundary>
+
+            <div className="flex flex-col items-center p-6 bg-background">
+              <Tabs
+                value={activeTab}
+                onValueChange={(val) => setActiveTab(val)}
+                className="w-full max-w-xl"
+              >
+                <TabsList className="mb-6 bg-white border border-gray-200">
+                  {navItems.map((item) => (
+                    <TabsTrigger
+                      key={item.value}
+                      value={item.value}
+                      className="text-slate-gray data-[state=active]:bg-electric-indigo data-[state=active]:text-ice-white"
+                    >
+                      {item.label}
+                    </TabsTrigger>
+                  ))}
+                </TabsList>
+              </Tabs>
+
+              <UserProfile
+                path={`/${activeTab}`}
+                routing="virtual"
+                appearance={{
+                  variables: {
+                    colorPrimary: brandColors['electric-indigo'],
+                    colorBackground: brandColors['ice-white'],
+                    colorText: brandColors['slate-gray'],
+                    colorTextSecondary: brandColors['gray-600'],
+                    fontFamily: 'Inter, sans-serif',
+                  },
+                  elements: {
+                    card: 'bg-white border border-gray-200',
+                    headerTitle: 'text-slate-gray',
+                    navbar: 'hidden',
+                  },
+                }}
+              />
+            </div>
+          </SidebarInset>
+        </div>
+      </SidebarProvider>
+    </div>
+  );
+};
 
 const Profile = () => (
   <>


### PR DESCRIPTION
## Summary
- create a horizontal tab list on the profile page
- hide Clerk's built-in navbar and sync tabs with `UserProfile`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68616fbf6b9c83239bb94ffc807fdc58