### PR TITLE
Add Deck Blueprint JSON schema and tests

### DIFF
--- a/examples/blueprint_full.json
+++ b/examples/blueprint_full.json
@@ -1,0 +1,27 @@
+{
+  "goal": {
+    "value": "Onboard customers",
+    "selection_source": "user",
+    "overrideable": false
+  },
+  "audience": {
+    "value": "marketers",
+    "selection_source": "user",
+    "overrideable": false
+  },
+  "section_sequence": {
+    "value": ["intro", "features", "pricing"],
+    "selection_source": "ai",
+    "overrideable": true
+  },
+  "theme": {
+    "value": "electric",
+    "selection_source": "ai",
+    "overrideable": true
+  },
+  "slide_library": {
+    "value": ["hero", "testimonials", "cta"],
+    "selection_source": "ai",
+    "overrideable": true
+  }
+}

--- a/examples/blueprint_minimal.json
+++ b/examples/blueprint_minimal.json
@@ -1,0 +1,12 @@
+{
+  "goal": {
+    "value": "Secure funding",
+    "selection_source": "user",
+    "overrideable": false
+  },
+  "audience": {
+    "value": "investors",
+    "selection_source": "user",
+    "overrideable": false
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react-swc": "^3.5.0",
+        "ajv": "^8.17.1",
         "autoprefixer": "^10.4.20",
         "eslint": "^9.29.0",
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
@@ -950,6 +951,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -962,6 +980,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "9.30.0",
@@ -3921,16 +3946,16 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -5562,6 +5587,30 @@
         "url": "https://eslint.org/donate"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -5785,6 +5834,23 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -6684,9 +6750,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -8526,6 +8592,16 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/resolve": {
       "version": "1.22.8",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react-swc": "^3.5.0",
+    "ajv": "^8.17.1",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.29.0",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",

--- a/schemas/deck-blueprint.schema.json
+++ b/schemas/deck-blueprint.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Deck Blueprint",
+  "type": "object",
+  "properties": {
+    "goal": { "$ref": "#/$defs/stringField" },
+    "audience": { "$ref": "#/$defs/stringField" },
+    "section_sequence": { "$ref": "#/$defs/stringArrayField" },
+    "theme": { "$ref": "#/$defs/stringField" },
+    "slide_library": { "$ref": "#/$defs/stringArrayField" }
+  },
+  "required": ["goal", "audience"],
+  "$defs": {
+    "stringField": {
+      "type": "object",
+      "properties": {
+        "value": { "type": "string" },
+        "selection_source": { "type": "string", "enum": ["user", "ai"] },
+        "overrideable": { "type": "boolean" }
+      },
+      "required": ["value", "selection_source", "overrideable"],
+      "additionalProperties": false
+    },
+    "stringArrayField": {
+      "type": "object",
+      "properties": {
+        "value": { "type": "array", "items": { "type": "string" } },
+        "selection_source": { "type": "string", "enum": ["user", "ai"] },
+        "overrideable": { "type": "boolean" }
+      },
+      "required": ["value", "selection_source", "overrideable"],
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/schema/deck-blueprint.schema.test.ts
+++ b/src/schema/deck-blueprint.schema.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { describe, expect, it } from 'vitest'
+import Ajv from 'ajv/dist/2020'
+
+const ajv = new Ajv()
+const schema = JSON.parse(readFileSync(join(__dirname, '../../schemas/deck-blueprint.schema.json'), 'utf-8'))
+const validate = ajv.compile(schema)
+
+describe('deck blueprint schema', () => {
+  it('validates minimal blueprint', () => {
+    const data = JSON.parse(readFileSync(join(__dirname, '../../examples/blueprint_minimal.json'), 'utf-8'))
+    const valid = validate(data)
+    expect(valid, JSON.stringify(validate.errors)).toBe(true)
+  })
+
+  it('validates full blueprint', () => {
+    const data = JSON.parse(readFileSync(join(__dirname, '../../examples/blueprint_full.json'), 'utf-8'))
+    const valid = validate(data)
+    expect(valid, JSON.stringify(validate.errors)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- add JSON schema describing deck blueprints
- provide minimal and full blueprint examples
- validate the examples with a Vitest test
- install Ajv for JSON Schema validation

## Testing
- `npm run lint -- --fix`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68619131d52c8323a51c37f7dd039cde