### PR TITLE
Implement blueprints API

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -83,3 +83,95 @@ paths:
       responses:
         "204":
           description: Event processed
+  /blueprints:
+    get:
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: includeDefaults
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: List of blueprints
+    post:
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "201":
+          description: Created blueprint
+  /blueprints/{blueprintId}:
+    get:
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: blueprintId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Blueprint details
+        "404":
+          description: Not found
+    put:
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: blueprintId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: Updated
+        "403":
+          description: Forbidden
+        "404":
+          description: Not found
+    delete:
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: blueprintId
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Deleted
+        "403":
+          description: Forbidden
+        "404":
+          description: Not found
+  /blueprints/{defaultId}/clone:
+    post:
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: defaultId
+          required: true
+          schema:
+            type: string
+      responses:
+        "201":
+          description: Cloned blueprint
+        "404":
+          description: Not found

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -9,6 +9,36 @@ export type Json =
 export type Database = {
   public: {
     Tables: {
+      blueprints: {
+        Row: {
+          blueprint: Json
+          blueprint_id: string
+          created_at: string
+          is_default: boolean
+          name: string
+          updated_at: string
+          user_id: string | null
+        }
+        Insert: {
+          blueprint: Json
+          blueprint_id?: string
+          created_at?: string
+          is_default?: boolean
+          name: string
+          updated_at?: string
+          user_id?: string | null
+        }
+        Update: {
+          blueprint?: Json
+          blueprint_id?: string
+          created_at?: string
+          is_default?: boolean
+          name?: string
+          updated_at?: string
+          user_id?: string | null
+        }
+        Relationships: []
+      },
       hubspot_contacts_cache: {
         Row: {
           id: string

--- a/src/server/blueprints.test.ts
+++ b/src/server/blueprints.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { handleRequest } from './blueprints'
+
+const insertMock = vi.fn()
+const updateMock = vi.fn()
+const deleteMock = vi.fn()
+const builder = {
+  or: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  then: (resolve: (v: unknown) => unknown) => Promise.resolve({ data: [], error: null }).then(resolve),
+}
+const orMock = builder.or
+const eqMock = builder.eq
+
+const fromMock = vi.fn(() => ({
+  select: vi.fn(() => builder),
+  insert: insertMock,
+  update: updateMock,
+  delete: deleteMock,
+  maybeSingle: vi.fn(),
+  single: vi.fn(),
+}))
+
+const authMock = {
+  getUser: vi.fn(() => Promise.resolve({ data: { user: { id: 'u1' } } })),
+}
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    from: fromMock,
+    auth: authMock,
+  })),
+}))
+
+beforeEach(() => {
+  insertMock.mockReset()
+  updateMock.mockReset()
+  deleteMock.mockReset()
+  orMock.mockClear()
+  eqMock.mockClear()
+})
+
+describe('handleRequest blueprints', () => {
+  it('lists user blueprints', async () => {
+    const res = await handleRequest(new Request('http://x/blueprints'))
+    expect(res.status).toBe(200)
+    expect(orMock).not.toHaveBeenCalled()
+    expect(eqMock).toHaveBeenCalledWith('user_id', 'u1')
+  })
+
+  it('includes defaults when requested', async () => {
+    const res = await handleRequest(new Request('http://x/blueprints?includeDefaults=true'))
+    expect(res.status).toBe(200)
+    expect(orMock).toHaveBeenCalled()
+  })
+})

--- a/src/server/blueprints.ts
+++ b/src/server/blueprints.ts
@@ -1,0 +1,151 @@
+import { createClient } from '@supabase/supabase-js'
+import type { Database } from '../integrations/supabase/types'
+import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
+
+export async function handleRequest(req: Request): Promise<Response> {
+  const { method, url } = req
+  const parsed = new URL(url)
+  const auth = req.headers.get('Authorization') || ''
+  const client = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    global: { headers: { Authorization: auth } },
+  })
+  const { data: { user } } = await client.auth.getUser()
+  if (!user) return new Response('Unauthorized', { status: 401 })
+
+  const path = parsed.pathname.replace(/\/+/g, '/').replace(/(^\/|\/$)/g, '')
+  const segments = path.split('/')
+
+  try {
+    if (segments[0] !== 'blueprints') {
+      return new Response('Not found', { status: 404 })
+    }
+
+    // /blueprints
+    if (segments.length === 1) {
+      if (method === 'GET') {
+        const includeDefaults = parsed.searchParams.get('includeDefaults') === 'true'
+        const query = client.from('blueprints').select('*')
+        if (includeDefaults) {
+          query.or(`is_default.eq.true,user_id.eq.${user.id}`)
+        } else {
+          query.eq('user_id', user.id)
+        }
+        const { data, error } = await query
+        if (error) throw error
+        return new Response(JSON.stringify(data), {
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+
+      if (method === 'POST') {
+        const body = await req.json()
+        const { data, error } = await client
+          .from('blueprints')
+          .insert({
+            user_id: user.id,
+            name: body.name,
+            blueprint: body.blueprint,
+          })
+          .select()
+          .single()
+        if (error) throw error
+        return new Response(JSON.stringify(data), {
+          headers: { 'Content-Type': 'application/json' },
+          status: 201,
+        })
+      }
+    }
+
+    // /blueprints/{id} or /blueprints/{id}/clone
+    if (segments.length >= 2) {
+      const id = segments[1]
+      if (segments.length === 3 && segments[2] === 'clone' && method === 'POST') {
+        // clone default blueprint
+        const { data: orig, error } = await client
+          .from('blueprints')
+          .select('*')
+          .eq('blueprint_id', id)
+          .single()
+        if (error) return new Response('Not Found', { status: 404 })
+        if (!orig.is_default) return new Response('Not Found', { status: 404 })
+        const { data, error: insertError } = await client
+          .from('blueprints')
+          .insert({
+            user_id: user.id,
+            name: orig.name,
+            blueprint: orig.blueprint,
+          })
+          .select()
+          .single()
+        if (insertError) throw insertError
+        return new Response(JSON.stringify(data), {
+          headers: { 'Content-Type': 'application/json' },
+          status: 201,
+        })
+      }
+
+      if (segments.length === 2) {
+        if (method === 'GET') {
+          const { data, error } = await client
+            .from('blueprints')
+            .select('*')
+            .eq('blueprint_id', id)
+            .maybeSingle()
+          if (error || !data) return new Response('Not Found', { status: 404 })
+          if (!data.is_default && data.user_id !== user.id) {
+            return new Response('Not Found', { status: 404 })
+          }
+          return new Response(JSON.stringify(data), {
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }
+
+        if (method === 'PUT') {
+          const { data: existing, error } = await client
+            .from('blueprints')
+            .select('is_default')
+            .eq('blueprint_id', id)
+            .maybeSingle()
+          if (error || !existing) return new Response('Not Found', { status: 404 })
+          if (existing.is_default) return new Response('Forbidden', { status: 403 })
+          const body = await req.json()
+          const { error: upError } = await client
+            .from('blueprints')
+            .update({
+              name: body.name,
+              blueprint: body.blueprint,
+              updated_at: new Date().toISOString(),
+            })
+            .eq('blueprint_id', id)
+            .eq('user_id', user.id)
+          if (upError) throw upError
+          return new Response(null, { status: 200 })
+        }
+
+        if (method === 'DELETE') {
+          const { data: existing, error } = await client
+            .from('blueprints')
+            .select('is_default, user_id')
+            .eq('blueprint_id', id)
+            .maybeSingle()
+          if (error || !existing) return new Response('Not Found', { status: 404 })
+          if (existing.is_default) return new Response('Forbidden', { status: 403 })
+          if (existing.user_id !== user.id) return new Response('Not Found', { status: 404 })
+          const { error: delError } = await client
+            .from('blueprints')
+            .delete()
+            .eq('blueprint_id', id)
+          if (delError) throw delError
+          return new Response(null, { status: 204 })
+        }
+      }
+    }
+
+    return new Response('Not found', { status: 404 })
+  } catch (err) {
+    console.error('Blueprint handler error:', err)
+    return new Response('Internal server error', { status: 500 })
+  }
+}
+
+export default { handleRequest }

--- a/supabase/functions/blueprints.ts
+++ b/supabase/functions/blueprints.ts
@@ -1,0 +1,3 @@
+import { handleRequest } from '../../src/server/blueprints.ts'
+
+Deno.serve(handleRequest)

--- a/supabase/migrations/20250701000000-f02b6680-0e84-4051-abd0-f4acd58f6cc1.sql
+++ b/supabase/migrations/20250701000000-f02b6680-0e84-4051-abd0-f4acd58f6cc1.sql
@@ -1,0 +1,39 @@
+BEGIN;
+
+-- Create blueprints table to store user and default deck blueprints
+CREATE TABLE public.blueprints (
+    blueprint_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    blueprint JSONB NOT NULL,
+    is_default BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_blueprints_user ON public.blueprints(user_id);
+
+ALTER TABLE public.blueprints ENABLE ROW LEVEL SECURITY;
+
+-- Allow users to select their own blueprints and public defaults
+CREATE POLICY "blueprints_select" ON public.blueprints
+    FOR SELECT USING (is_default OR user_id = (auth.jwt() ->> 'sub')::uuid);
+
+-- Allow inserting blueprints owned by the user
+CREATE POLICY "blueprints_insert" ON public.blueprints
+    FOR INSERT WITH CHECK (user_id = (auth.jwt() ->> 'sub')::uuid AND NOT is_default);
+
+-- Allow updating own non-default blueprints
+CREATE POLICY "blueprints_update" ON public.blueprints
+    FOR UPDATE USING (user_id = (auth.jwt() ->> 'sub')::uuid AND NOT is_default);
+
+-- Allow deleting own non-default blueprints
+CREATE POLICY "blueprints_delete" ON public.blueprints
+    FOR DELETE USING (user_id = (auth.jwt() ->> 'sub')::uuid AND NOT is_default);
+
+GRANT USAGE, SELECT, INSERT, UPDATE, DELETE ON public.blueprints TO authenticated;
+GRANT SELECT ON public.blueprints TO anon;
+
+COMMENT ON TABLE public.blueprints IS 'Deck blueprints for generating presentations';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add REST endpoints for managing slide deck blueprints
- create `blueprints` table via migration
- document API routes in OpenAPI spec
- expose edge function and server handler
- include tests for listing blueprints

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6861b500387c8323b38b965df52afb70