### PR TITLE
Add new blueprint columns

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -12,6 +12,12 @@ export type Database = {
       blueprints: {
         Row: {
           blueprint: Json
+          goal: string
+          audience: string
+          section_sequence: string[]
+          theme: string
+          slide_library: string[]
+          extra_metadata: Json
           blueprint_id: string
           created_at: string
           is_default: boolean
@@ -21,6 +27,12 @@ export type Database = {
         }
         Insert: {
           blueprint: Json
+          goal?: string
+          audience?: string
+          section_sequence?: string[]
+          theme?: string
+          slide_library?: string[]
+          extra_metadata?: Json
           blueprint_id?: string
           created_at?: string
           is_default?: boolean
@@ -30,6 +42,12 @@ export type Database = {
         }
         Update: {
           blueprint?: Json
+          goal?: string
+          audience?: string
+          section_sequence?: string[]
+          theme?: string
+          slide_library?: string[]
+          extra_metadata?: Json
           blueprint_id?: string
           created_at?: string
           is_default?: boolean

--- a/supabase/migrations/20250702000000-7d79c6ee-6e4e-42f8-9fd2-1e6a3ee90479.sql
+++ b/supabase/migrations/20250702000000-7d79c6ee-6e4e-42f8-9fd2-1e6a3ee90479.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+ALTER TABLE public.blueprints
+  ADD COLUMN goal TEXT NOT NULL DEFAULT '',
+  ADD COLUMN audience TEXT NOT NULL DEFAULT '',
+  ADD COLUMN section_sequence TEXT[] NOT NULL DEFAULT '{}',
+  ADD COLUMN theme TEXT NOT NULL DEFAULT '',
+  ADD COLUMN slide_library TEXT[] NOT NULL DEFAULT '{}',
+  ADD COLUMN extra_metadata JSONB NOT NULL DEFAULT '{}';
+
+CREATE INDEX idx_blueprints_theme ON public.blueprints(theme);
+CREATE INDEX idx_blueprints_section_sequence ON public.blueprints USING GIN(section_sequence);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- extend `blueprints` table with additional core fields
- regenerate Supabase types for the new columns

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6861bc2e23708323a0a07dfe0a453f7e