### PR TITLE
Update blueprint schema

### DIFF
--- a/examples/blueprint_full.json
+++ b/examples/blueprint_full.json
@@ -23,5 +23,8 @@
     "value": ["hero", "testimonials", "cta"],
     "selection_source": "ai",
     "overrideable": true
+  },
+  "extra_metadata": {
+    "notes": "Slides should be concise"
   }
 }

--- a/schemas/deck-blueprint.schema.json
+++ b/schemas/deck-blueprint.schema.json
@@ -7,7 +7,8 @@
     "audience": { "$ref": "#/$defs/stringField" },
     "section_sequence": { "$ref": "#/$defs/stringArrayField" },
     "theme": { "$ref": "#/$defs/stringField" },
-    "slide_library": { "$ref": "#/$defs/stringArrayField" }
+    "slide_library": { "$ref": "#/$defs/stringArrayField" },
+    "extra_metadata": { "type": "object", "additionalProperties": true }
   },
   "required": ["goal", "audience"],
   "$defs": {


### PR DESCRIPTION
## Summary
- support `extra_metadata` field in deck blueprint schema
- illustrate `extra_metadata` usage in blueprint example

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6861c1c48e6c8323a16b92153271374a