### PR TITLE
Remove goal and audience from blueprint schema

### DIFF
--- a/examples/blueprint_full.json
+++ b/examples/blueprint_full.json
@@ -1,14 +1,4 @@
 {
-  "goal": {
-    "value": "Onboard customers",
-    "selection_source": "user",
-    "overrideable": false
-  },
-  "audience": {
-    "value": "marketers",
-    "selection_source": "user",
-    "overrideable": false
-  },
   "section_sequence": {
     "value": ["intro", "features", "pricing"],
     "selection_source": "ai",

--- a/examples/blueprint_minimal.json
+++ b/examples/blueprint_minimal.json
@@ -1,12 +1,3 @@
 {
-  "goal": {
-    "value": "Secure funding",
-    "selection_source": "user",
-    "overrideable": false
-  },
-  "audience": {
-    "value": "investors",
-    "selection_source": "user",
-    "overrideable": false
-  }
+  
 }

--- a/schemas/deck-blueprint.schema.json
+++ b/schemas/deck-blueprint.schema.json
@@ -3,13 +3,11 @@
   "title": "Deck Blueprint",
   "type": "object",
   "properties": {
-    "goal": { "$ref": "#/$defs/stringField" },
-    "audience": { "$ref": "#/$defs/stringField" },
     "section_sequence": { "$ref": "#/$defs/stringArrayField" },
     "theme": { "$ref": "#/$defs/stringField" },
     "slide_library": { "$ref": "#/$defs/stringArrayField" }
   },
-  "required": ["goal", "audience"],
+  "required": [],
   "$defs": {
     "stringField": {
       "type": "object",

--- a/src/schema/deck-blueprint.schema.test.ts
+++ b/src/schema/deck-blueprint.schema.test.ts
@@ -19,4 +19,13 @@ describe('deck blueprint schema', () => {
     const valid = validate(data)
     expect(valid, JSON.stringify(validate.errors)).toBe(true)
   })
+
+  it('rejects deprecated fields', () => {
+    const data = {
+      goal: { value: 'foo', selection_source: 'user', overrideable: false },
+      audience: { value: 'bar', selection_source: 'user', overrideable: false }
+    }
+    const valid = validate(data)
+    expect(valid).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary
- drop `goal` and `audience` from `deck-blueprint` JSON schema
- update example blueprints
- test that removed fields are rejected

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6861c43fb5d4832385b706664f5399e5