### PR TITLE
Implement blueprint column mapping

### DIFF
--- a/src/server/blueprints.ts
+++ b/src/server/blueprints.ts
@@ -2,6 +2,64 @@ import { createClient } from '@supabase/supabase-js'
 import type { Database } from '../integrations/supabase/types'
 import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
 
+// Map incoming JSON data to table columns and extras
+function parseBlueprintData(data: Record<string, unknown> | null | undefined) {
+  const {
+    goal = '',
+    audience = '',
+    section_sequence = [],
+    theme = '',
+    slide_library = [],
+    ...extra_metadata
+  } = (data || {}) as Record<string, unknown>
+
+  return {
+    goal: goal as string,
+    audience: audience as string,
+    section_sequence: section_sequence as string[],
+    theme: theme as string,
+    slide_library: slide_library as string[],
+    extra_metadata,
+    blueprint: data || {},
+  }
+}
+
+function rowToResponse(
+  row: Database['public']['Tables']['blueprints']['Row'],
+) {
+  const {
+    blueprint_id,
+    user_id,
+    name,
+    is_default,
+    created_at,
+    updated_at,
+    goal,
+    audience,
+    section_sequence,
+    theme,
+    slide_library,
+    extra_metadata,
+  } = row
+
+  return {
+    blueprint_id,
+    user_id,
+    name,
+    is_default,
+    created_at,
+    updated_at,
+    data: {
+      goal,
+      audience,
+      section_sequence,
+      theme,
+      slide_library,
+      ...(extra_metadata as Record<string, unknown>),
+    },
+  }
+}
+
 export async function handleRequest(req: Request): Promise<Response> {
   const { method, url } = req
   const parsed = new URL(url)
@@ -32,24 +90,34 @@ export async function handleRequest(req: Request): Promise<Response> {
         }
         const { data, error } = await query
         if (error) throw error
-        return new Response(JSON.stringify(data), {
-          headers: { 'Content-Type': 'application/json' },
-        })
+        return new Response(
+          JSON.stringify(data.map(rowToResponse)),
+          {
+            headers: { 'Content-Type': 'application/json' },
+          },
+        )
       }
 
       if (method === 'POST') {
         const body = await req.json()
+        const parsed = parseBlueprintData(body.data)
         const { data, error } = await client
           .from('blueprints')
           .insert({
             user_id: user.id,
             name: body.name,
-            blueprint: body.blueprint,
+            blueprint: parsed.blueprint,
+            goal: parsed.goal,
+            audience: parsed.audience,
+            section_sequence: parsed.section_sequence,
+            theme: parsed.theme,
+            slide_library: parsed.slide_library,
+            extra_metadata: parsed.extra_metadata as Database['public']['Tables']['blueprints']['Insert']['extra_metadata'],
           })
           .select()
           .single()
         if (error) throw error
-        return new Response(JSON.stringify(data), {
+        return new Response(JSON.stringify(rowToResponse(data)), {
           headers: { 'Content-Type': 'application/json' },
           status: 201,
         })
@@ -74,11 +142,17 @@ export async function handleRequest(req: Request): Promise<Response> {
             user_id: user.id,
             name: orig.name,
             blueprint: orig.blueprint,
+            goal: orig.goal,
+            audience: orig.audience,
+            section_sequence: orig.section_sequence,
+            theme: orig.theme,
+            slide_library: orig.slide_library,
+            extra_metadata: orig.extra_metadata as Database['public']['Tables']['blueprints']['Insert']['extra_metadata'],
           })
           .select()
           .single()
         if (insertError) throw insertError
-        return new Response(JSON.stringify(data), {
+        return new Response(JSON.stringify(rowToResponse(data)), {
           headers: { 'Content-Type': 'application/json' },
           status: 201,
         })
@@ -95,7 +169,7 @@ export async function handleRequest(req: Request): Promise<Response> {
           if (!data.is_default && data.user_id !== user.id) {
             return new Response('Not Found', { status: 404 })
           }
-          return new Response(JSON.stringify(data), {
+          return new Response(JSON.stringify(rowToResponse(data)), {
             headers: { 'Content-Type': 'application/json' },
           })
         }
@@ -109,11 +183,18 @@ export async function handleRequest(req: Request): Promise<Response> {
           if (error || !existing) return new Response('Not Found', { status: 404 })
           if (existing.is_default) return new Response('Forbidden', { status: 403 })
           const body = await req.json()
+          const parsed = parseBlueprintData(body.data)
           const { error: upError } = await client
             .from('blueprints')
             .update({
               name: body.name,
-              blueprint: body.blueprint,
+              blueprint: parsed.blueprint,
+              goal: parsed.goal,
+              audience: parsed.audience,
+              section_sequence: parsed.section_sequence,
+              theme: parsed.theme,
+              slide_library: parsed.slide_library,
+              extra_metadata: parsed.extra_metadata as Database['public']['Tables']['blueprints']['Update']['extra_metadata'],
               updated_at: new Date().toISOString(),
             })
             .eq('blueprint_id', id)


### PR DESCRIPTION
## Summary
- map blueprint data into new columns in Supabase handler
- include helper for serializing rows back into blueprint data
- clone and update operations preserve metadata JSON

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6861c861a0a483239c6a08001eec3e49