### PR TITLE
Add section-template API

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -175,3 +175,23 @@ paths:
           description: Cloned blueprint
         "404":
           description: Not found
+  /section-templates:
+    get:
+      description: List section-template mappings
+      responses:
+        "200":
+          description: List of mappings
+  /section-templates/{sectionId}:
+    get:
+      description: Get mapping for a section
+      parameters:
+        - in: path
+          name: sectionId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Section mapping
+        "404":
+          description: Not found

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -356,6 +356,27 @@ export type Database = {
         }
         Relationships: []
       }
+      section_templates: {
+        Row: {
+          section_id: string
+          purpose: string
+          default_templates: string[]
+          editable: boolean
+        }
+        Insert: {
+          section_id?: string
+          purpose: string
+          default_templates: string[]
+          editable?: boolean
+        }
+        Update: {
+          section_id?: string
+          purpose?: string
+          default_templates?: string[]
+          editable?: boolean
+        }
+        Relationships: []
+      }
     }
     Views: {
       [_ in never]: never

--- a/src/server/section_templates.test.ts
+++ b/src/server/section_templates.test.ts
@@ -1,16 +1,19 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { handleRequest } from './section_templates'
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
+
+let handleRequest: typeof import('./section_templates').handleRequest
 
 const builder = {
   select: vi.fn().mockReturnThis(),
   eq: vi.fn().mockReturnThis(),
   maybeSingle: vi.fn(),
 }
-// eslint-disable-next-line no-var
-var fromMock: ReturnType<typeof vi.fn>
-vi.mock('@supabase/supabase-js', () => {
-  fromMock = vi.fn(() => builder)
-  return { createClient: vi.fn(() => ({ from: fromMock })) }
+let fromMock: ReturnType<typeof vi.fn>
+beforeAll(async () => {
+  vi.doMock('@supabase/supabase-js', () => {
+    fromMock = vi.fn(() => builder)
+    return { createClient: vi.fn(() => ({ from: fromMock })) }
+  })
+  ;({ handleRequest } = await import('./section_templates'))
 })
 
 beforeEach(() => {

--- a/src/server/section_templates.test.ts
+++ b/src/server/section_templates.test.ts
@@ -6,6 +6,7 @@ const builder = {
   eq: vi.fn().mockReturnThis(),
   maybeSingle: vi.fn(),
 }
+// eslint-disable-next-line no-var
 var fromMock: ReturnType<typeof vi.fn>
 vi.mock('@supabase/supabase-js', () => {
   fromMock = vi.fn(() => builder)

--- a/src/server/section_templates.test.ts
+++ b/src/server/section_templates.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { handleRequest } from './section_templates'
+
+const builder = {
+  select: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  maybeSingle: vi.fn(),
+}
+var fromMock: ReturnType<typeof vi.fn>
+vi.mock('@supabase/supabase-js', () => {
+  fromMock = vi.fn(() => builder)
+  return { createClient: vi.fn(() => ({ from: fromMock })) }
+})
+
+beforeEach(() => {
+  builder.select.mockReturnThis()
+  builder.eq.mockReturnThis()
+  builder.maybeSingle.mockResolvedValue({ data: null, error: null })
+})
+
+describe('sectionTemplates handleRequest', () => {
+  it('lists mappings', async () => {
+    builder.select.mockResolvedValueOnce({ data: [], error: null })
+    const res = await handleRequest(new Request('http://x/section-templates'))
+    expect(res.status).toBe(200)
+    expect(fromMock).toHaveBeenCalledWith('section_templates')
+  })
+
+  it('reads one mapping', async () => {
+    builder.maybeSingle.mockResolvedValueOnce({ data: { section_id: 'intro' }, error: null })
+    const res = await handleRequest(new Request('http://x/section-templates/intro'))
+    expect(builder.eq).toHaveBeenCalledWith('section_id', 'intro')
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 404 when missing', async () => {
+    builder.maybeSingle.mockResolvedValueOnce({ data: null, error: null })
+    const res = await handleRequest(new Request('http://x/section-templates/miss'))
+    expect(res.status).toBe(404)
+  })
+})

--- a/src/server/section_templates.ts
+++ b/src/server/section_templates.ts
@@ -1,0 +1,47 @@
+import { createClient } from '@supabase/supabase-js'
+import type { Database } from '../integrations/supabase/types'
+import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
+
+const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+
+export async function handleRequest(req: Request): Promise<Response> {
+  const url = new URL(req.url)
+  const segments = url.pathname.replace(/^\/+|\/+$/g, '').split('/')
+
+  if (segments[0] !== 'section-templates') {
+    return new Response('Not found', { status: 404 })
+  }
+
+  try {
+    if (req.method === 'GET') {
+      if (segments.length === 1) {
+        const { data, error } = await supabase
+          .from('section_templates')
+          .select('*')
+        if (error) throw error
+        return new Response(JSON.stringify(data), {
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      if (segments.length === 2) {
+        const id = segments[1]
+        const { data, error } = await supabase
+          .from('section_templates')
+          .select('*')
+          .eq('section_id', id)
+          .maybeSingle()
+        if (error) throw error
+        if (!data) return new Response('Not Found', { status: 404 })
+        return new Response(JSON.stringify(data), {
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+    }
+    return new Response('Not found', { status: 404 })
+  } catch (err) {
+    console.error('Section templates handler error:', err)
+    return new Response('Internal server error', { status: 500 })
+  }
+}
+
+export default { handleRequest }

--- a/supabase/functions/section-templates.ts
+++ b/supabase/functions/section-templates.ts
@@ -1,0 +1,3 @@
+import { handleRequest } from '../../src/server/section_templates.ts'
+
+Deno.serve(handleRequest)

--- a/supabase/migrations/20250702000000-section_templates.sql
+++ b/supabase/migrations/20250702000000-section_templates.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+CREATE TABLE public.section_templates (
+    section_id TEXT PRIMARY KEY,
+    purpose TEXT NOT NULL,
+    default_templates TEXT[] NOT NULL,
+    editable BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE INDEX idx_section_templates_editable ON public.section_templates USING BTREE (editable);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- create section_templates table migration
- define Section Templates table in Supabase types
- add REST handler for listing and reading mappings
- expose Supabase function for section-templates
- document endpoints in OpenAPI spec
- test handleRequest for section-templates

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6861d15814ac8323b45399e8557b9c8c