### PR TITLE
Add blueprint creation wizard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Dashboard from "./pages/Dashboard";
 import Profile from "./pages/Profile";
 import Slides from "./pages/Slides";
 import NewDeckFlow from "./pages/NewDeckFlow";
+import BlueprintWizard from "./pages/BlueprintWizard";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -25,6 +26,7 @@ const App = () => (
           <Route path="/slides" element={<Slides />} />
           <Route path="/profile" element={<Profile />} />
           <Route path="/new-deck" element={<NewDeckFlow />} />
+          <Route path="/new-blueprint" element={<BlueprintWizard />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/pages/BlueprintWizard.tsx
+++ b/src/pages/BlueprintWizard.tsx
@@ -1,0 +1,153 @@
+import React, { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+
+interface Blueprint {
+  blueprint_id: string
+  name: string
+  is_default: boolean
+  data: { section_sequence?: { value: string[] } }
+}
+
+const BlueprintWizard = () => {
+  const navigate = useNavigate()
+  const [step, setStep] = useState(0)
+  const [catalog, setCatalog] = useState<Blueprint[]>([])
+  const [selected, setSelected] = useState<Blueprint | null>(null)
+  const [goal, setGoal] = useState('')
+  const [audience, setAudience] = useState('')
+  const [sections, setSections] = useState<string[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (step === 0) {
+      fetch('/api/blueprints?includeDefaults=true')
+        .then(r => r.json())
+        .then(setCatalog)
+        .catch(err => console.error('Fetch catalog error:', err))
+    }
+  }, [step])
+
+  const handleImport = async () => {
+    if (!selected) return
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/blueprints/${selected.blueprint_id}/clone`, { method: 'POST' })
+      const json = await res.json()
+      setSelected(json)
+      setStep(1)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleSuggest = async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/sections/suggest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ goal, audience }),
+      })
+      const json = await res.json()
+      setSections(json.sections || [])
+      setStep(2)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleSave = async () => {
+    if (!selected) return
+    setLoading(true)
+    try {
+      await fetch(`/api/blueprints/${selected.blueprint_id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: selected.name,
+          data: { goal, audience, section_sequence: sections },
+        }),
+      })
+      navigate('/dashboard')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-ice-white p-6 space-y-6">
+      {step === 0 && (
+        <Card className="max-w-xl mx-auto">
+          <CardHeader>
+            <CardTitle>Select a Blueprint</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {catalog.map(bp => (
+              <Button
+                key={bp.blueprint_id}
+                variant={selected?.blueprint_id === bp.blueprint_id ? 'default' : 'outline'}
+                className="w-full justify-start"
+                onClick={() => setSelected(bp)}
+              >
+                {bp.name}
+              </Button>
+            ))}
+            <div className="flex justify-end pt-4">
+              <Button disabled={!selected || loading} onClick={handleImport}>
+                Import
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === 1 && (
+        <Card className="max-w-xl mx-auto">
+          <CardHeader>
+            <CardTitle>Goal and Audience</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Input placeholder="Goal" value={goal} onChange={e => setGoal(e.target.value)} />
+            <Input placeholder="Audience" value={audience} onChange={e => setAudience(e.target.value)} />
+            <div className="flex justify-between pt-4">
+              <Button variant="secondary" onClick={() => setStep(0)}>
+                Back
+              </Button>
+              <Button onClick={handleSuggest} disabled={!goal || !audience || loading}>
+                Generate Outline
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === 2 && (
+        <Card className="max-w-xl mx-auto">
+          <CardHeader>
+            <CardTitle>Outline</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <ul className="list-disc pl-5 text-gray-600 space-y-1">
+              {sections.map((s, i) => (
+                <li key={i}>{s}</li>
+              ))}
+            </ul>
+            <div className="flex justify-between pt-4">
+              <Button variant="secondary" onClick={() => setStep(1)}>
+                Back
+              </Button>
+              <Button onClick={handleSave} disabled={!sections.length || loading}>
+                Save Blueprint
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}
+
+export default BlueprintWizard

--- a/src/server/sections.ts
+++ b/src/server/sections.ts
@@ -1,0 +1,43 @@
+import { createClient } from '@supabase/supabase-js'
+import OpenAI from 'openai'
+import type { Database } from '../integrations/supabase/types'
+import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
+
+const openai = new OpenAI()
+
+export async function handleRequest(req: Request): Promise<Response> {
+  const url = new URL(req.url)
+  const path = url.pathname.replace(/^\/+|\/+$/g, '')
+
+  if (path !== 'sections/suggest' || req.method !== 'POST') {
+    return new Response('Not found', { status: 404 })
+  }
+
+  const auth = req.headers.get('Authorization') || ''
+  const client = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    global: { headers: { Authorization: auth } },
+  })
+  const { data: { user } } = await client.auth.getUser()
+  if (!user) return new Response('Unauthorized', { status: 401 })
+
+  const { goal = '', audience = '' } = await req.json()
+
+  try {
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4.1-mini',
+      messages: [
+        { role: 'system', content: 'Return a JSON array of short presentation section titles.' },
+        { role: 'user', content: `Goal: ${goal}\nAudience: ${audience}` },
+      ],
+    })
+    const sections = JSON.parse(completion.choices[0].message.content || '[]')
+    return new Response(JSON.stringify({ sections }), {
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (err) {
+    console.error('Section suggest error:', err)
+    return new Response('Internal server error', { status: 500 })
+  }
+}
+
+export default { handleRequest }

--- a/supabase/functions/sections.ts
+++ b/supabase/functions/sections.ts
@@ -1,0 +1,3 @@
+import { handleRequest } from '../../src/server/sections.ts'
+
+Deno.serve(handleRequest)

--- a/supabase/migrations/20250703000000-blueprint_indexes.sql
+++ b/supabase/migrations/20250703000000-blueprint_indexes.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+-- Indexes to speed up blueprint queries
+CREATE INDEX idx_blueprints_is_default ON public.blueprints(is_default);
+CREATE INDEX idx_blueprints_goal ON public.blueprints(goal);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add React page for blueprint wizard
- create server handler and edge function for section suggestions
- index blueprint fields for faster catalog fetches
- wire up new wizard route

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6861dde4d1808323ad6980e158e9bcd4