### PR TITLE
Implement rule-based section suggestion endpoint

### DIFF
--- a/src/server/sections.test.ts
+++ b/src/server/sections.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+let handleRequest: typeof import('./sections').handleRequest
+
+const authMock = { getUser: vi.fn(() => Promise.resolve({ data: { user: { id: 'u1' } } })) }
+
+const createMock = vi.fn()
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({ auth: authMock })),
+}))
+
+vi.mock('openai', () => ({
+  default: class {
+    chat = { completions: { create: createMock } }
+  },
+}))
+
+beforeEach(async () => {
+  vi.resetModules()
+  createMock.mockClear()
+  ;({ handleRequest } = await import('./sections'))
+})
+
+describe('handleRequest sections', () => {
+  it('returns rule-based sections when matched', async () => {
+    const req = new Request('http://x/sections/suggest', {
+      method: 'POST',
+      body: JSON.stringify({ goal: 'QBR', audience: 'executive' }),
+    })
+    const res = await handleRequest(req)
+    const json = await res.json()
+    expect(json.sections).toContain('highlights')
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to LLM when no rule', async () => {
+    createMock.mockResolvedValueOnce({ choices: [{ message: { content: '["a"]' } }] })
+    const req = new Request('http://x/sections/suggest', {
+      method: 'POST',
+      body: JSON.stringify({ goal: 'unknown', audience: 'foo' }),
+    })
+    const res = await handleRequest(req)
+    const json = await res.json()
+    expect(json.sections).toEqual(['a'])
+    expect(createMock).toHaveBeenCalled()
+  })
+
+  it('caches results', async () => {
+    createMock.mockResolvedValueOnce({ choices: [{ message: { content: '["c"]' } }] })
+    const body = JSON.stringify({ goal: 'cache', audience: 'me' })
+    await handleRequest(new Request('http://x/sections/suggest', { method: 'POST', body }))
+    await handleRequest(new Request('http://x/sections/suggest', { method: 'POST', body }))
+    expect(createMock).toHaveBeenCalledTimes(1)
+  })
+})
+

--- a/src/server/sections.ts
+++ b/src/server/sections.ts
@@ -3,13 +3,78 @@ import OpenAI from 'openai'
 import type { Database } from '../integrations/supabase/types'
 import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
 
+interface Rule {
+  goalPatterns: string[]
+  audiencePatterns: string[]
+  sections: string[]
+}
+
+const ruleSet: Rule[] = [
+  {
+    goalPatterns: ['quarterly review', 'business review', 'qbr'],
+    audiencePatterns: ['executive', 'leadership', 'board'],
+    sections: ['intro', 'highlights', 'metrics', 'roadmap', 'q_and_a'],
+  },
+  {
+    goalPatterns: ['project proposal', 'proposal', 'pitch'],
+    audiencePatterns: ['investor', 'stakeholder', 'client'],
+    sections: [
+      'intro',
+      'problem',
+      'solution',
+      'benefits',
+      'costs',
+      'next_steps',
+      'q_and_a',
+    ],
+  },
+  {
+    goalPatterns: ['training', 'onboarding', 'tutorial'],
+    audiencePatterns: ['new hire', 'employee', 'team'],
+    sections: ['intro', 'agenda', 'overview', 'lesson', 'exercise', 'summary'],
+  },
+  {
+    goalPatterns: ['sales pitch', 'sales presentation'],
+    audiencePatterns: ['customer', 'prospect'],
+    sections: [
+      'intro',
+      'need',
+      'solution',
+      'case_study',
+      'pricing',
+      'next_steps',
+      'q_and_a',
+    ],
+  },
+  {
+    goalPatterns: ['product demo', 'demo'],
+    audiencePatterns: ['prospect', 'client'],
+    sections: [
+      'intro',
+      'features',
+      'demo',
+      'benefits',
+      'pricing',
+      'q_and_a',
+    ],
+  },
+]
+
+interface CacheEntry {
+  sections: string[]
+  expires: number
+}
+
+const cache = new Map<string, CacheEntry>()
+
 const openai = new OpenAI()
 
 export async function handleRequest(req: Request): Promise<Response> {
   const url = new URL(req.url)
   const path = url.pathname.replace(/^\/+|\/+$/g, '')
 
-  if (path !== 'sections/suggest' || req.method !== 'POST') {
+  const normalized = path.replace(/^api\//, '')
+  if (normalized !== 'sections/suggest' || req.method !== 'POST') {
     return new Response('Not found', { status: 404 })
   }
 
@@ -20,24 +85,51 @@ export async function handleRequest(req: Request): Promise<Response> {
   const { data: { user } } = await client.auth.getUser()
   if (!user) return new Response('Unauthorized', { status: 401 })
 
-  const { goal = '', audience = '' } = await req.json()
+  const { goal = '', audience = '', creative = false } = await req.json()
 
-  try {
-    const completion = await openai.chat.completions.create({
-      model: 'gpt-4.1-mini',
-      messages: [
-        { role: 'system', content: 'Return a JSON array of short presentation section titles.' },
-        { role: 'user', content: `Goal: ${goal}\nAudience: ${audience}` },
-      ],
-    })
-    const sections = JSON.parse(completion.choices[0].message.content || '[]')
-    return new Response(JSON.stringify({ sections }), {
+  const key = `${goal.toLowerCase()}|${audience.toLowerCase()}|${creative ? 1 : 0}`
+  const cached = cache.get(key)
+  if (cached && cached.expires > Date.now()) {
+    return new Response(JSON.stringify({ sections: cached.sections }), {
       headers: { 'Content-Type': 'application/json' },
     })
-  } catch (err) {
-    console.error('Section suggest error:', err)
-    return new Response('Internal server error', { status: 500 })
   }
+
+  const g = goal.toLowerCase()
+  const a = audience.toLowerCase()
+  const rule =
+    !creative &&
+    ruleSet.find(r =>
+      r.goalPatterns.some(p => g.includes(p)) &&
+      r.audiencePatterns.some(p => a.includes(p))
+    )
+
+  let sections: string[]
+  if (rule) {
+    sections = rule.sections
+  } else {
+    try {
+      const completion = await openai.chat.completions.create({
+        model: 'gpt-3.5-turbo',
+        max_tokens: 50,
+        messages: [
+          {
+            role: 'user',
+            content: `Suggest 5–7 section IDs for goal="${goal}" and audience="${audience}".`,
+          },
+        ],
+      })
+      sections = JSON.parse(completion.choices[0].message.content || '[]')
+    } catch (err) {
+      console.error('Section suggest error:', err)
+      sections = ['intro', 'context', 'analysis', 'recommendation', 'q_and_a']
+    }
+  }
+
+  cache.set(key, { sections, expires: Date.now() + 24 * 60 * 60 * 1000 })
+  return new Response(JSON.stringify({ sections }), {
+    headers: { 'Content-Type': 'application/json' },
+  })
 }
 
 export default { handleRequest }


### PR DESCRIPTION
## Summary
- add curated rule set and caching layer for section suggestions
- return cached or rule-based results before invoking LLM
- fall back to GPT-3.5 with minimal prompt
- expose new tests for section suggestion logic

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6861f52662648323bd9355950d14de3a