### PR TITLE
Implement slide template CRUD API

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -195,3 +195,66 @@ paths:
           description: Section mapping
         "404":
           description: Not found
+  /slide-templates:
+    get:
+      description: List slide templates
+      responses:
+        "200":
+          description: List of templates
+    post:
+      description: Create a slide template
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "201":
+          description: Created template
+  /slide-templates/{templateId}:
+    get:
+      description: Get a slide template
+      parameters:
+        - in: path
+          name: templateId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Slide template
+        "404":
+          description: Not found
+    put:
+      description: Update a slide template
+      parameters:
+        - in: path
+          name: templateId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: Updated
+        "404":
+          description: Not found
+    delete:
+      description: Delete a slide template
+      parameters:
+        - in: path
+          name: templateId
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Deleted
+        "404":
+          description: Not found

--- a/src/server/slide_templates.test.ts
+++ b/src/server/slide_templates.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
+
+let handleRequest: typeof import('./slide_templates').handleRequest
+
+const builder = {
+  select: vi.fn(() => builder),
+  eq: vi.fn(() => builder),
+  maybeSingle: vi.fn(),
+  single: vi.fn(),
+  insert: vi.fn(() => builder),
+  update: vi.fn(() => builder),
+  delete: vi.fn(() => builder),
+}
+let fromMock: ReturnType<typeof vi.fn>
+
+beforeAll(async () => {
+  vi.doMock('@supabase/supabase-js', () => {
+    fromMock = vi.fn(() => builder)
+    return { createClient: vi.fn(() => ({ from: fromMock })) }
+  })
+  ;({ handleRequest } = await import('./slide_templates'))
+})
+
+beforeEach(() => {
+  builder.select.mockReturnThis()
+  builder.eq.mockReturnThis()
+  builder.maybeSingle.mockResolvedValue({ data: null, error: null })
+  builder.single.mockResolvedValue({ data: null, error: null })
+})
+
+describe('slideTemplates handleRequest', () => {
+  it('lists templates', async () => {
+    builder.select.mockResolvedValueOnce({ data: [], error: null })
+    const res = await handleRequest(new Request('http://x/slide-templates'))
+    expect(res.status).toBe(200)
+    expect(fromMock).toHaveBeenCalledWith('slide_templates')
+  })
+
+  it('reads one template', async () => {
+    builder.maybeSingle.mockResolvedValueOnce({ data: { template_id: 't1' }, error: null })
+    const res = await handleRequest(new Request('http://x/slide-templates/t1'))
+    expect(res.status).toBe(200)
+    expect(builder.eq).toHaveBeenCalledWith('template_id', 't1')
+  })
+
+  it('returns 404 when missing', async () => {
+    builder.maybeSingle.mockResolvedValueOnce({ data: null, error: null })
+    const res = await handleRequest(new Request('http://x/slide-templates/miss'))
+    expect(res.status).toBe(404)
+  })
+
+  it('creates template', async () => {
+    builder.single.mockResolvedValueOnce({ data: { template_id: 'n' }, error: null })
+    const res = await handleRequest(new Request('http://x/slide-templates', { method: 'POST', body: '{}' }))
+    expect(builder.insert).toHaveBeenCalled()
+    expect(res.status).toBe(201)
+  })
+
+  it('updates template', async () => {
+    builder.maybeSingle.mockResolvedValueOnce({ data: { template_id: 'u' }, error: null })
+    const res = await handleRequest(new Request('http://x/slide-templates/u', { method: 'PUT', body: '{}' }))
+    expect(builder.update).toHaveBeenCalled()
+    expect(res.status).toBe(200)
+  })
+
+  it('deletes template', async () => {
+    builder.maybeSingle.mockResolvedValueOnce({ data: { template_id: 'd' }, error: null })
+    const res = await handleRequest(new Request('http://x/slide-templates/d', { method: 'DELETE' }))
+    expect(builder.delete).toHaveBeenCalled()
+    expect(res.status).toBe(204)
+  })
+})

--- a/src/server/slide_templates.ts
+++ b/src/server/slide_templates.ts
@@ -1,0 +1,91 @@
+import { createClient } from '@supabase/supabase-js'
+import type { Database } from '../integrations/supabase/types'
+import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
+
+const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+
+export async function handleRequest(req: Request): Promise<Response> {
+  const url = new URL(req.url)
+  const segments = url.pathname.replace(/^\/+|\/+$/g, '').split('/')
+
+  if (segments[0] !== 'slide-templates') {
+    return new Response('Not found', { status: 404 })
+  }
+
+  try {
+    if (req.method === 'GET') {
+      if (segments.length === 1) {
+        const { data, error } = await supabase
+          .from('slide_templates')
+          .select('*')
+        if (error) throw error
+        return new Response(JSON.stringify(data), {
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      if (segments.length === 2) {
+        const id = segments[1]
+        const { data, error } = await supabase
+          .from('slide_templates')
+          .select('*')
+          .eq('template_id', id)
+          .maybeSingle()
+        if (error) throw error
+        if (!data) return new Response('Not Found', { status: 404 })
+        return new Response(JSON.stringify(data), {
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+    }
+
+    if (req.method === 'POST' && segments.length === 1) {
+      const body = await req.json()
+      const { data, error } = await supabase
+        .from('slide_templates')
+        .insert(body)
+        .select()
+        .single()
+      if (error) throw error
+      return new Response(JSON.stringify(data), {
+        headers: { 'Content-Type': 'application/json' },
+        status: 201,
+      })
+    }
+
+    if (req.method === 'PUT' && segments.length === 2) {
+      const id = segments[1]
+      const body = await req.json()
+      const { data, error } = await supabase
+        .from('slide_templates')
+        .update({ ...body, updated_at: new Date().toISOString() })
+        .eq('template_id', id)
+        .select()
+        .maybeSingle()
+      if (error) throw error
+      if (!data) return new Response('Not Found', { status: 404 })
+      return new Response(JSON.stringify(data), {
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    if (req.method === 'DELETE' && segments.length === 2) {
+      const id = segments[1]
+      const { data, error } = await supabase
+        .from('slide_templates')
+        .delete()
+        .eq('template_id', id)
+        .select('template_id')
+        .maybeSingle()
+      if (error) throw error
+      if (!data) return new Response('Not Found', { status: 404 })
+      return new Response(null, { status: 204 })
+    }
+
+    return new Response('Not found', { status: 404 })
+  } catch (err) {
+    console.error('Slide templates handler error:', err)
+    return new Response('Internal server error', { status: 500 })
+  }
+}
+
+export default { handleRequest }

--- a/supabase/functions/slide-templates.ts
+++ b/supabase/functions/slide-templates.ts
@@ -1,0 +1,3 @@
+import { handleRequest } from '../../src/server/slide_templates.ts'
+
+Deno.serve(handleRequest)

--- a/supabase/migrations/20250704000000-slide_templates_indexes.sql
+++ b/supabase/migrations/20250704000000-slide_templates_indexes.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+-- Indexes to speed up slide template queries
+CREATE INDEX idx_slide_templates_name ON public.slide_templates(name);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add slide template CRUD handler and edge function
- document new slide template endpoints in API docs
- create vitest coverage for slide template operations
- add migration for slide template index

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_6861fdfbe2188323be4e718c8018ffb9