### PR TITLE
Add theme support for blueprint rendering

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -377,6 +377,30 @@ export type Database = {
         }
         Relationships: []
       }
+      themes: {
+        Row: {
+          theme_id: string
+          name: string
+          css: string
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          theme_id?: string
+          name: string
+          css: string
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          theme_id?: string
+          name?: string
+          css?: string
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
     }
     Views: {
       [_ in never]: never

--- a/src/server/blueprints.test.ts
+++ b/src/server/blueprints.test.ts
@@ -53,4 +53,10 @@ describe('handleRequest blueprints', () => {
     expect(res.status).toBe(200)
     expect(orMock).toHaveBeenCalled()
   })
+
+  it('filters by theme', async () => {
+    const res = await handleRequest(new Request('http://x/blueprints?theme=dark'))
+    expect(res.status).toBe(200)
+    expect(eqMock.mock.calls.some(c => c[0] === 'theme' && c[1] === 'dark')).toBe(true)
+  })
 })

--- a/src/server/blueprints.ts
+++ b/src/server/blueprints.ts
@@ -88,6 +88,10 @@ export async function handleRequest(req: Request): Promise<Response> {
         } else {
           query.eq('user_id', user.id)
         }
+        const themeFilter = parsed.searchParams.get('theme')
+        if (themeFilter) {
+          query.eq('theme', themeFilter)
+        }
         const { data, error } = await query
         if (error) throw error
         return new Response(

--- a/src/server/decks_render.test.ts
+++ b/src/server/decks_render.test.ts
@@ -28,7 +28,11 @@ beforeEach(() => {
 
 describe('decks render handler', () => {
   it('returns presentation URLs', async () => {
-    builder.maybeSingle.mockResolvedValueOnce({ data: { blueprint_id: 'b1', user_id: 'u1', is_default: false, section_sequence: ['intro'] }, error: null })
+    builder.maybeSingle.mockResolvedValueOnce({
+      data: { blueprint_id: 'b1', user_id: 'u1', is_default: false, section_sequence: ['intro'], theme: 'brand' },
+      error: null,
+    })
+    builder.maybeSingle.mockResolvedValueOnce({ data: { css: '.brand{}' }, error: null })
     builder.in.mockResolvedValueOnce({ data: [{ section_id: 'intro', default_templates: ['t1'] }], error: null })
     const body = JSON.stringify({ blueprint_id: 'b1' })
     const res = await handleRequest(new Request('http://x/decks/render', { method: 'POST', body }))
@@ -36,16 +40,22 @@ describe('decks render handler', () => {
     const json = await res.json()
     expect(json.presentation_url).toContain('/decks/')
     expect(json.assets_bundle_url).toContain('/decks/')
+    expect(fromMock).toHaveBeenCalledWith('themes')
   })
 
   it('applies slide overrides', async () => {
-    builder.maybeSingle.mockResolvedValueOnce({ data: { blueprint_id: 'b1', user_id: 'u1', is_default: false, section_sequence: ['solution'] }, error: null })
+    builder.maybeSingle.mockResolvedValueOnce({
+      data: { blueprint_id: 'b1', user_id: 'u1', is_default: false, section_sequence: ['solution'], theme: 'brand' },
+      error: null,
+    })
+    builder.maybeSingle.mockResolvedValueOnce({ data: { css: '.brand{}' }, error: null })
     builder.in.mockResolvedValueOnce({ data: [{ section_id: 'solution', default_templates: ['t1'] }], error: null })
     const body = JSON.stringify({ blueprint_id: 'b1', overrides: { solution: ['custom'] } })
     const res = await handleRequest(new Request('http://x/decks/render', { method: 'POST', body }))
     const json = await res.json()
     expect(json.html).toContain('custom')
     expect(fromMock).toHaveBeenCalledWith('section_templates')
+    expect(fromMock).toHaveBeenCalledWith('themes')
   })
 
   it('returns 404 when blueprint missing', async () => {

--- a/src/server/decks_render.ts
+++ b/src/server/decks_render.ts
@@ -7,7 +7,7 @@ interface SlideData {
   templates: string[]
 }
 
-function buildHtml(slidesData: SlideData[]): string {
+function buildHtml(slidesData: SlideData[], themeCss: string): string {
   const slides = slidesData
     .map(({ section, templates }) =>
       `<section data-section="${section}" data-templates="${templates.join(',')}"><h2>${section}</h2></section>`,
@@ -18,6 +18,7 @@ function buildHtml(slidesData: SlideData[]): string {
 <head>
   <meta charset="utf-8">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js/dist/reveal.css">
+  <style>${themeCss}</style>
   <script src="https://cdn.jsdelivr.net/npm/reveal.js/dist/reveal.js"></script>
 </head>
 <body>
@@ -73,7 +74,13 @@ export async function handleRequest(req: Request): Promise<Response> {
       templates: (overrides[section] as string[]) || defaults.get(section) || [],
     }))
 
-    const html = buildHtml(slidesData)
+    const { data: themeRow } = await client
+      .from('themes')
+      .select('css')
+      .eq('theme_id', data.theme)
+      .maybeSingle()
+
+    const html = buildHtml(slidesData, themeRow?.css || '')
     const deckId = crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2)
     const base = `https://example.com/decks/${deckId}`
 

--- a/supabase/migrations/20250705000000-themes.sql
+++ b/supabase/migrations/20250705000000-themes.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+-- Table to store brand themes
+CREATE TABLE public.themes (
+    theme_id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    css TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- create `themes` table via migration
- extend Supabase types for new `themes` table
- allow `/api/blueprints` to filter by theme
- load theme CSS when rendering decks
- test blueprint filtering and theme application

## Testing
- `npm run lint -- --fix`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68620a2116308323b319661719596844