### PR TITLE
Fix search function query format

### DIFF
--- a/src/hooks/useSecureHubSpotData.ts
+++ b/src/hooks/useSecureHubSpotData.ts
@@ -20,7 +20,7 @@ export const useSecureHubSpotData = () => {
 
     try {
       const { data, error: functionError } = await supabase.functions.invoke('search_contacts', {
-        body: JSON.stringify({ q: query, limit }),
+        query: { q: query, limit },
       });
 
       if (functionError) {


### PR DESCRIPTION
## Summary
- adjust `useSecureHubSpotData.searchContacts` to pass query params instead of JSON body

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_686211a57ac0832385dead573b34dc60