### PR TITLE
Fix rate limiter duplication

### DIFF
--- a/src/server/rate_limiter_memory.ts
+++ b/src/server/rate_limiter_memory.ts
@@ -40,3 +40,4 @@ export class RateLimiterMemory {
 
 const rateLimiterMemory = new RateLimiterMemory();
 export default rateLimiterMemory;
+export { RateLimiterMemory };

--- a/supabase/functions/search_contacts/index.ts
+++ b/supabase/functions/search_contacts/index.ts
@@ -1,34 +1,10 @@
 
 import { createClient, type SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { RateLimiterMemory } from '../../../src/server/rate_limiter_memory.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
-
-// Rate limiter implementation with enhanced security
-class RateLimiterMemory {
-  private tokens: Map<string, { count: number; resetTime: number }> = new Map()
-  
-  constructor(private maxRequests: number, private windowMs: number) {}
-  
-  async take(key: string): Promise<void> {
-    const now = Date.now()
-    const bucket = this.tokens.get(key) || { count: 0, resetTime: now + this.windowMs }
-    
-    if (now > bucket.resetTime) {
-      bucket.count = 0
-      bucket.resetTime = now + this.windowMs
-    }
-    
-    if (bucket.count >= this.maxRequests) {
-      const waitTime = bucket.resetTime - now
-      throw new Error('Rate limit exceeded')
-    }
-    
-    bucket.count++
-    this.tokens.set(key, bucket)
-  }
 }
 
 const rateLimiter = new RateLimiterMemory(10, 60000) // 10 requests per minute


### PR DESCRIPTION
## Summary
- export `RateLimiterMemory` for Deno usage
- reuse `RateLimiterMemory` in `search_contacts` edge function
- remove duplicate implementation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_686211a9a7808323b21117b2904ac3f2