### PR TITLE
Wrap data fetches in useCallback

### DIFF
--- a/src/hooks/useDecks.ts
+++ b/src/hooks/useDecks.ts
@@ -1,5 +1,5 @@
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useSupabaseClient } from './useSupabaseClient';
 
 export interface DeckSummary {
@@ -14,7 +14,7 @@ export const useDecks = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchDecks = async () => {
+  const fetchDecks = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -42,9 +42,9 @@ export const useDecks = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [supabase]);
 
-  const getSlides = async (deckId: string) => {
+  const getSlides = useCallback(async (deckId: string) => {
     try {
       setLoading(true);
       setError(null);
@@ -68,11 +68,11 @@ export const useDecks = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [supabase]);
 
   useEffect(() => {
     fetchDecks();
-  }, []);
+  }, [fetchDecks]);
 
   return {
     decks,

--- a/src/hooks/usePresentationPlans.ts
+++ b/src/hooks/usePresentationPlans.ts
@@ -1,5 +1,5 @@
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useUser } from '@clerk/clerk-react';
 import { useSupabaseClient } from './useSupabaseClient';
 import type { Tables, TablesInsert, TablesUpdate } from '@/integrations/supabase/types';
@@ -15,7 +15,7 @@ export const usePresentationPlans = (presentationId?: string) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchPlans = async () => {
+  const fetchPlans = useCallback(async () => {
     if (!user || !presentationId) return;
 
     try {
@@ -44,7 +44,7 @@ export const usePresentationPlans = (presentationId?: string) => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user, presentationId, supabase]);
 
   const createPlan = async (planData: PresentationPlanInsert) => {
     if (!user) return;
@@ -114,7 +114,7 @@ export const usePresentationPlans = (presentationId?: string) => {
     } else {
       setPlans([]);
     }
-  }, [user, presentationId]);
+  }, [user, presentationId, fetchPlans]);
 
   return {
     plans,

--- a/src/hooks/usePresentations.ts
+++ b/src/hooks/usePresentations.ts
@@ -1,5 +1,5 @@
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useUser } from '@clerk/clerk-react';
 import { useSupabaseClient } from './useSupabaseClient';
 import type { Tables, TablesInsert, TablesUpdate } from '@/integrations/supabase/types';
@@ -15,7 +15,7 @@ export const usePresentations = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchPresentations = async () => {
+  const fetchPresentations = useCallback(async () => {
     if (!user) return;
 
     try {
@@ -38,7 +38,7 @@ export const usePresentations = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user, supabase]);
 
   const createPresentation = async (presentationData: Omit<PresentationInsert, 'user_id'>) => {
     if (!user) return;
@@ -139,7 +139,7 @@ export const usePresentations = () => {
     } else {
       setPresentations([]);
     }
-  }, [user]);
+  }, [user, fetchPresentations]);
 
   return {
     presentations,

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,5 +1,5 @@
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useUser } from '@clerk/clerk-react';
 import { useSupabaseClient } from './useSupabaseClient';
 import type { Tables, TablesInsert, TablesUpdate } from '@/integrations/supabase/types';
@@ -15,7 +15,7 @@ export const useProfile = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchProfile = async () => {
+  const fetchProfile = useCallback(async () => {
     if (!user) return;
 
     try {
@@ -39,7 +39,7 @@ export const useProfile = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user, supabase]);
 
   const createProfile = async (profileData: Omit<ProfileInsert, 'id'>) => {
     if (!user) return;
@@ -107,7 +107,7 @@ export const useProfile = () => {
     } else {
       setProfile(null);
     }
-  }, [user]);
+  }, [user, fetchProfile]);
 
   return {
     profile,

--- a/src/hooks/useSlideGenerations.ts
+++ b/src/hooks/useSlideGenerations.ts
@@ -1,5 +1,5 @@
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useUser } from '@clerk/clerk-react';
 import { useSupabaseClient } from './useSupabaseClient';
 import type { Tables, TablesInsert, TablesUpdate } from '@/integrations/supabase/types';
@@ -15,7 +15,7 @@ export const useSlideGenerations = (presentationId?: string) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchGenerations = async () => {
+  const fetchGenerations = useCallback(async () => {
     if (!user || !presentationId) return;
 
     try {
@@ -39,7 +39,7 @@ export const useSlideGenerations = (presentationId?: string) => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user, presentationId, supabase]);
 
   const createGeneration = async (generationData: SlideGenerationInsert) => {
     if (!user) return;
@@ -112,7 +112,7 @@ export const useSlideGenerations = (presentationId?: string) => {
     } else {
       setGenerations([]);
     }
-  }, [user, presentationId]);
+  }, [user, presentationId, fetchGenerations]);
 
   return {
     generations,

--- a/src/hooks/useSlideTemplates.ts
+++ b/src/hooks/useSlideTemplates.ts
@@ -1,5 +1,5 @@
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useSupabaseClient } from './useSupabaseClient';
 import type { Tables, TablesInsert, TablesUpdate } from '@/integrations/supabase/types';
 
@@ -13,7 +13,7 @@ export const useSlideTemplates = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchTemplates = async () => {
+  const fetchTemplates = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -34,7 +34,7 @@ export const useSlideTemplates = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [supabase]);
 
   const createTemplate = async (templateData: SlideTemplateInsert) => {
     try {
@@ -121,7 +121,7 @@ export const useSlideTemplates = () => {
 
   useEffect(() => {
     fetchTemplates();
-  }, []);
+  }, [fetchTemplates]);
 
   return {
     templates,


### PR DESCRIPTION
## Summary
- wrap data-fetching functions with `useCallback`
- add memoized functions to dependency arrays
- update hooks to avoid lint warnings

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_686211bee83c832393feb323b83ba0ed