### PR TITLE
Add getSupabaseClient helper

### DIFF
--- a/src/server/blueprints.test.ts
+++ b/src/server/blueprints.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { handleRequest } from './blueprints'
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
+
+let handleRequest: typeof import('./blueprints').handleRequest
 
 const insertMock = vi.fn()
 const updateMock = vi.fn()
@@ -25,12 +26,15 @@ const authMock = {
   getUser: vi.fn(() => Promise.resolve({ data: { user: { id: 'u1' } } })),
 }
 
-vi.mock('@supabase/supabase-js', () => ({
-  createClient: vi.fn(() => ({
-    from: fromMock,
-    auth: authMock,
-  })),
-}))
+beforeAll(async () => {
+  vi.doMock('@supabase/supabase-js', () => ({
+    createClient: vi.fn(() => ({
+      from: fromMock,
+      auth: authMock,
+    })),
+  }))
+  ;({ handleRequest } = await import('./blueprints'))
+})
 
 beforeEach(() => {
   insertMock.mockReset()

--- a/src/server/blueprints.ts
+++ b/src/server/blueprints.ts
@@ -1,6 +1,5 @@
-import { createClient } from '@supabase/supabase-js'
 import type { Database } from '../integrations/supabase/types'
-import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
+import { getSupabaseClient } from './supabaseClient'
 
 // Map incoming JSON data to table columns and extras
 function parseBlueprintData(data: Record<string, unknown> | null | undefined) {
@@ -64,9 +63,7 @@ export async function handleRequest(req: Request): Promise<Response> {
   const { method, url } = req
   const parsed = new URL(url)
   const auth = req.headers.get('Authorization') || ''
-  const client = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
-    global: { headers: { Authorization: auth } },
-  })
+  const client = getSupabaseClient(auth)
   const { data: { user } } = await client.auth.getUser()
   if (!user) return new Response('Unauthorized', { status: 401 })
 

--- a/src/server/decks_render.ts
+++ b/src/server/decks_render.ts
@@ -1,6 +1,5 @@
-import { createClient } from '@supabase/supabase-js'
 import type { Database } from '../integrations/supabase/types'
-import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
+import { getSupabaseClient } from './supabaseClient'
 
 interface SlideData {
   section: string
@@ -37,9 +36,7 @@ export async function handleRequest(req: Request): Promise<Response> {
   }
 
   const auth = req.headers.get('Authorization') || ''
-  const client = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
-    global: { headers: { Authorization: auth } },
-  })
+  const client = getSupabaseClient(auth)
   const { data: { user } } = await client.auth.getUser()
   if (!user) return new Response('Unauthorized', { status: 401 })
 

--- a/src/server/hubspot_fetch_contacts.ts
+++ b/src/server/hubspot_fetch_contacts.ts
@@ -1,11 +1,11 @@
 
-import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { type SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '../integrations/supabase/types'
 import { ensureAccessToken } from '../integrations/hubspot/tokens'
 import rateLimiter from './rate_limiter_memory'
-import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
+import { getSupabaseClient } from './supabaseClient'
 
-const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+const supabase = getSupabaseClient()
 
 export interface HubSpotContact {
   id: string

--- a/src/server/hubspot_webhook.ts
+++ b/src/server/hubspot_webhook.ts
@@ -1,15 +1,11 @@
 
 import express, { RequestHandler, Request, Response } from 'express';
 import { requireAuth } from '@clerk/express';
-import { createClient } from '@supabase/supabase-js';
+import { getSupabaseClient } from './supabaseClient';
 import { createHmac } from 'crypto';
-import {
-  HUBSPOT_APP_SECRET as HUBSPOT_SECRET,
-  SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY,
-} from './config';
+import { HUBSPOT_APP_SECRET as HUBSPOT_SECRET } from './config';
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+const supabase = getSupabaseClient();
 
 export interface AuthedRequest extends Request {
   rawBody?: string;

--- a/src/server/search_contacts.ts
+++ b/src/server/search_contacts.ts
@@ -1,12 +1,7 @@
 
-import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { type SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '../integrations/supabase/types'
-
-import {
-  SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY,
-} from './config'
-import supabase from './supabaseClient'
+import supabase, { getSupabaseClient } from './supabaseClient'
 
 import { searchContacts as hubspotSearch } from '../integrations/hubspot/client'
 
@@ -115,9 +110,7 @@ export async function handleRequest(req: Request): Promise<Response> {
   const limit = parseInt(url.searchParams.get('limit') || '10', 10)
 
   const auth = req.headers.get('Authorization') || ''
-  const client = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
-    global: { headers: { Authorization: auth } },
-  })
+  const client = getSupabaseClient(auth)
   
   const {
     data: { user },

--- a/src/server/section_templates.ts
+++ b/src/server/section_templates.ts
@@ -1,8 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
 import type { Database } from '../integrations/supabase/types'
-import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
+import { getSupabaseClient } from './supabaseClient'
 
-const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+const supabase = getSupabaseClient()
 
 export async function handleRequest(req: Request): Promise<Response> {
   const url = new URL(req.url)

--- a/src/server/sections.ts
+++ b/src/server/sections.ts
@@ -1,7 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
 import OpenAI from 'openai'
 import type { Database } from '../integrations/supabase/types'
-import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
+import { getSupabaseClient } from './supabaseClient'
 
 interface Rule {
   goalPatterns: string[]
@@ -101,9 +100,7 @@ export async function handleRequest(req: Request): Promise<Response> {
   }
 
   const auth = req.headers.get('Authorization') || ''
-  const client = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
-    global: { headers: { Authorization: auth } },
-  })
+  const client = getSupabaseClient(auth)
   const { data: { user } } = await client.auth.getUser()
   if (!user) return new Response('Unauthorized', { status: 401 })
 

--- a/src/server/slide_templates.ts
+++ b/src/server/slide_templates.ts
@@ -1,8 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
 import type { Database } from '../integrations/supabase/types'
-import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
+import { getSupabaseClient } from './supabaseClient'
 
-const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+const supabase = getSupabaseClient()
 
 export async function handleRequest(req: Request): Promise<Response> {
   const url = new URL(req.url)

--- a/src/server/supabaseClient.ts
+++ b/src/server/supabaseClient.ts
@@ -2,6 +2,11 @@ import { createClient } from '@supabase/supabase-js'
 import type { Database } from '../integrations/supabase/types'
 import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
 
-const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+export function getSupabaseClient(auth?: string) {
+  const options = auth ? { global: { headers: { Authorization: auth } } } : undefined
+  return createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, options)
+}
+
+const supabase = getSupabaseClient()
 
 export default supabase


### PR DESCRIPTION
## Summary
- create `getSupabaseClient` helper for server-side Supabase access
- use new helper across server modules
- update blueprint tests to import modules after mocking

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686211d9f8ec832388fd51a1ff24ff50