### PR TITLE
Refactor Supabase client usage

### DIFF
--- a/src/integrations/hubspot/client.ts
+++ b/src/integrations/hubspot/client.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '../supabase/types'
 import rateLimiter from '../../server/rate_limiter_memory'
-import supabase from '../../server/supabaseClient'
+import { getSupabaseClient } from '../../server/supabaseClient'
 import { ensureAccessToken } from './tokens'
 import crypto from 'crypto'
 
@@ -29,7 +29,7 @@ export async function searchContacts(
   portal_id: string,
   q: string,
   limit: number,
-  sb: SupabaseClient<Database> = supabase,
+  sb: SupabaseClient<Database> = getSupabaseClient(),
   fetchFn: typeof fetch = fetch
 ): Promise<HubSpotContact[]> {
   const accessToken = await ensureAccessToken(portal_id, sb, fetchFn)
@@ -64,7 +64,7 @@ export async function searchContacts(
 
 export async function postNote(
   { portal_id, hubspot_object_id, app_record_url }: PostNoteInput,
-  sb: SupabaseClient<Database> = supabase,
+  sb: SupabaseClient<Database> = getSupabaseClient(),
   fetchFn: typeof fetch = fetch
 ): Promise<{ noteId: string } | { error: unknown }> {
   try {

--- a/src/integrations/hubspot/tokens.ts
+++ b/src/integrations/hubspot/tokens.ts
@@ -1,6 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '../supabase/types'
-import supabase from '../../server/supabaseClient'
+import { getSupabaseClient } from '../../server/supabaseClient'
 import {
   HUBSPOT_CLIENT_ID,
   HUBSPOT_CLIENT_SECRET,
@@ -16,7 +16,7 @@ export interface HubSpotTokenResponse {
 
 export async function ensureAccessToken(
   portal_id: string,
-  sb: SupabaseClient<Database> = supabase,
+  sb: SupabaseClient<Database> = getSupabaseClient(),
   fetchFn: typeof fetch = fetch
 ): Promise<string> {
   const { data, error } = await sb

--- a/src/server/blueprints.test.ts
+++ b/src/server/blueprints.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { handleRequest } from './blueprints'
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
+
+let handleRequest: typeof import('./blueprints').handleRequest
 
 const insertMock = vi.fn()
 const updateMock = vi.fn()
@@ -25,12 +26,18 @@ const authMock = {
   getUser: vi.fn(() => Promise.resolve({ data: { user: { id: 'u1' } } })),
 }
 
-vi.mock('@supabase/supabase-js', () => ({
+vi.doMock('@supabase/supabase-js', () => ({
   createClient: vi.fn(() => ({
     from: fromMock,
     auth: authMock,
   })),
 }))
+
+beforeAll(async () => {
+  process.env.SUPABASE_URL = 'http://localhost'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'key'
+  ;({ handleRequest } = await import('./blueprints'))
+})
 
 beforeEach(() => {
   insertMock.mockReset()

--- a/src/server/blueprints.ts
+++ b/src/server/blueprints.ts
@@ -1,6 +1,5 @@
-import { createClient } from '@supabase/supabase-js'
 import type { Database } from '../integrations/supabase/types'
-import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
+import { getSupabaseClient } from './supabaseClient'
 
 // Map incoming JSON data to table columns and extras
 function parseBlueprintData(data: Record<string, unknown> | null | undefined) {
@@ -64,9 +63,7 @@ export async function handleRequest(req: Request): Promise<Response> {
   const { method, url } = req
   const parsed = new URL(url)
   const auth = req.headers.get('Authorization') || ''
-  const client = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
-    global: { headers: { Authorization: auth } },
-  })
+  const client = getSupabaseClient(auth)
   const { data: { user } } = await client.auth.getUser()
   if (!user) return new Response('Unauthorized', { status: 401 })
 

--- a/src/server/decks_render.ts
+++ b/src/server/decks_render.ts
@@ -1,6 +1,5 @@
-import { createClient } from '@supabase/supabase-js'
 import type { Database } from '../integrations/supabase/types'
-import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
+import { getSupabaseClient } from './supabaseClient'
 import { devLog } from '../lib/dev-log'
 
 interface SlideData {
@@ -38,9 +37,7 @@ export async function handleRequest(req: Request): Promise<Response> {
   }
 
   const auth = req.headers.get('Authorization') || ''
-  const client = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
-    global: { headers: { Authorization: auth } },
-  })
+  const client = getSupabaseClient(auth)
   const { data: { user } } = await client.auth.getUser()
   if (!user) return new Response('Unauthorized', { status: 401 })
 

--- a/src/server/hubspot_fetch_contacts.test.ts
+++ b/src/server/hubspot_fetch_contacts.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 const upsertCache = vi.fn()
 const upsertCursor = vi.fn()
 
-vi.mock('@supabase/supabase-js', () => ({
+vi.doMock('@supabase/supabase-js', () => ({
   createClient: vi.fn(() => ({
     from: (table: string) => ({
       upsert: table === 'hubspot_contacts_cache' ? upsertCache : upsertCursor,

--- a/src/server/hubspot_fetch_contacts.ts
+++ b/src/server/hubspot_fetch_contacts.ts
@@ -1,11 +1,11 @@
 
-import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { type SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '../integrations/supabase/types'
 import { ensureAccessToken } from '../integrations/hubspot/tokens'
 import rateLimiter from './rate_limiter_memory'
-import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
+import { getSupabaseClient } from './supabaseClient'
 
-const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+const supabase = getSupabaseClient()
 
 export interface HubSpotContact {
   id: string

--- a/src/server/hubspot_webhook.test.ts
+++ b/src/server/hubspot_webhook.test.ts
@@ -16,7 +16,7 @@ const deleteTokensMock = vi.fn().mockResolvedValue({});
 const deleteCacheMock = vi.fn().mockResolvedValue({});
 const deleteCursorsMock = vi.fn().mockResolvedValue({});
 
-vi.mock('@supabase/supabase-js', () => ({
+vi.doMock('@supabase/supabase-js', () => ({
   createClient: vi.fn(() => ({
     from: (table: string) => ({
       insert: table === 'hubspot_events_raw' ? insertMock : undefined,

--- a/src/server/hubspot_webhook.ts
+++ b/src/server/hubspot_webhook.ts
@@ -1,16 +1,14 @@
 
 import express, { RequestHandler, Request, Response } from 'express';
 import { requireAuth } from '@clerk/express';
-import { createClient } from '@supabase/supabase-js';
+import { getSupabaseClient } from './supabaseClient';
 import { createHmac } from 'crypto';
 import {
   HUBSPOT_APP_SECRET as HUBSPOT_SECRET,
-  SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY,
 } from './config';
 import { devLog } from '../lib/dev-log';
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+const supabase = getSupabaseClient();
 
 export interface AuthedRequest extends Request {
   rawBody?: string;

--- a/src/server/search_contacts.ts
+++ b/src/server/search_contacts.ts
@@ -1,12 +1,10 @@
 
-import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { type SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '../integrations/supabase/types'
 
 import {
-  SUPABASE_URL,
-  SUPABASE_SERVICE_ROLE_KEY,
 } from './config'
-import supabase from './supabaseClient'
+import { getSupabaseClient } from './supabaseClient'
 
 import { searchContacts as hubspotSearch } from '../integrations/hubspot/client'
 
@@ -42,7 +40,7 @@ export async function searchLocal(
   portal_id: string,
   q: string,
   limit: number,
-  sb: SupabaseClient<Database> = supabase,
+  sb: SupabaseClient<Database> = getSupabaseClient(),
 ): Promise<ContactRecord[]> {
   const { data } = await sb
     .from('hubspot_contacts_cache')
@@ -58,7 +56,7 @@ async function searchRemote(
   portal_id: string,
   q: string,
   limit: number,
-  sb: SupabaseClient<Database> = supabase,
+  sb: SupabaseClient<Database> = getSupabaseClient(),
   fetchFn: typeof fetch = fetch,
 ): Promise<ContactRecord[]> {
   const rows = await hubspotSearch(portal_id, q, limit, sb, fetchFn)
@@ -83,7 +81,7 @@ export async function searchContacts(
   portal_id: string,
   q: string,
   limit: number,
-  sb: SupabaseClient<Database> = supabase,
+  sb: SupabaseClient<Database> = getSupabaseClient(),
   fetchFn: typeof fetch = fetch,
 ): Promise<ContactRecord[]> {
   // Validate input
@@ -115,9 +113,7 @@ export async function handleRequest(req: Request): Promise<Response> {
   const limit = parseInt(url.searchParams.get('limit') || '10', 10)
 
   const auth = req.headers.get('Authorization') || ''
-  const client = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
-    global: { headers: { Authorization: auth } },
-  })
+  const client = getSupabaseClient(auth)
   
   const {
     data: { user },

--- a/src/server/section_templates.ts
+++ b/src/server/section_templates.ts
@@ -1,8 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
 import type { Database } from '../integrations/supabase/types'
-import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
+import { getSupabaseClient } from './supabaseClient'
 
-const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+const supabase = getSupabaseClient()
 
 export async function handleRequest(req: Request): Promise<Response> {
   const url = new URL(req.url)

--- a/src/server/sections.test.ts
+++ b/src/server/sections.test.ts
@@ -6,7 +6,7 @@ const authMock = { getUser: vi.fn(() => Promise.resolve({ data: { user: { id: 'u
 
 const createMock = vi.fn()
 
-vi.mock('@supabase/supabase-js', () => ({
+vi.doMock('@supabase/supabase-js', () => ({
   createClient: vi.fn(() => ({ auth: authMock })),
 }))
 

--- a/src/server/sections.ts
+++ b/src/server/sections.ts
@@ -1,7 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
 import OpenAI from 'openai'
 import type { Database } from '../integrations/supabase/types'
-import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
+import { getSupabaseClient } from './supabaseClient'
 
 interface Rule {
   goalPatterns: string[]
@@ -101,9 +100,7 @@ export async function handleRequest(req: Request): Promise<Response> {
   }
 
   const auth = req.headers.get('Authorization') || ''
-  const client = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
-    global: { headers: { Authorization: auth } },
-  })
+  const client = getSupabaseClient(auth)
   const { data: { user } } = await client.auth.getUser()
   if (!user) return new Response('Unauthorized', { status: 401 })
 

--- a/src/server/slide_templates.ts
+++ b/src/server/slide_templates.ts
@@ -1,8 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
 import type { Database } from '../integrations/supabase/types'
-import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
+import { getSupabaseClient } from './supabaseClient'
 
-const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+const supabase = getSupabaseClient()
 
 export async function handleRequest(req: Request): Promise<Response> {
   const url = new URL(req.url)

--- a/src/server/supabaseClient.ts
+++ b/src/server/supabaseClient.ts
@@ -1,7 +1,13 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '../integrations/supabase/types'
 import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config'
 
-const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+export function getSupabaseClient(
+  authHeader?: string,
+): SupabaseClient<Database> {
+  return createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    ...(authHeader ? { global: { headers: { Authorization: authHeader } } } : {}),
+  })
+}
 
-export default supabase
+export default getSupabaseClient


### PR DESCRIPTION
## Summary
- export `getSupabaseClient` helper returning a Supabase client
- use helper in server modules
- adapt tests to mock Supabase and dynamically import handlers

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686215a923c083238182fc2a4157baa4