### PR TITLE
Add Supabase blueprints & themes type definitions

### DIFF
--- a/src/hooks/useSecureSupabase.ts
+++ b/src/hooks/useSecureSupabase.ts
@@ -11,9 +11,9 @@ export const useSecureSupabase = () => {
   const [error, setError] = useState<string | null>(null);
 
   const secureQuery = useCallback(async <T>(
-    operation: () => Promise<{ data: T | null; error: any }>,
+    operation: () => Promise<{ data: T | null; error: unknown }>,
     operationType: string,
-    validation?: (data: any) => boolean
+    validation?: (data: T) => boolean
   ) => {
     if (!user) {
       const errorMessage = 'Authentication required for this operation';

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -9,6 +9,54 @@ export type Json =
 export type Database = {
   public: {
     Tables: {
+      blueprints: {
+        Row: {
+          audience: string
+          blueprint: Json
+          blueprint_id: string
+          created_at: string
+          extra_metadata: Json
+          goal: string
+          is_default: boolean
+          name: string
+          section_sequence: string[]
+          slide_library: string[]
+          theme: string
+          updated_at: string
+          user_id: string | null
+        }
+        Insert: {
+          audience?: string
+          blueprint: Json
+          blueprint_id?: string
+          created_at?: string
+          extra_metadata?: Json
+          goal?: string
+          is_default?: boolean
+          name: string
+          section_sequence?: string[]
+          slide_library?: string[]
+          theme?: string
+          updated_at?: string
+          user_id?: string | null
+        }
+        Update: {
+          audience?: string
+          blueprint?: Json
+          blueprint_id?: string
+          created_at?: string
+          extra_metadata?: Json
+          goal?: string
+          is_default?: boolean
+          name?: string
+          section_sequence?: string[]
+          slide_library?: string[]
+          theme?: string
+          updated_at?: string
+          user_id?: string | null
+        }
+        Relationships: []
+      }
       hubspot_contacts_cache: {
         Row: {
           id: string
@@ -304,6 +352,30 @@ export type Database = {
           output_schema?: Json
           prompt_template?: string
           template_id?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      themes: {
+        Row: {
+          created_at: string
+          css: string
+          name: string
+          theme_id: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          css: string
+          name: string
+          theme_id: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          css?: string
+          name?: string
+          theme_id?: string
           updated_at?: string
         }
         Relationships: []


### PR DESCRIPTION
## Summary
- recreate the `blueprints` table interface with all fields
- restore `themes` table definition
- fix lint issues in `useSecureSupabase`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68628a15e28883239281253e5c521c65