### PR TITLE
Use query string for contact search

### DIFF
--- a/src/hooks/useSecureHubSpotData.ts
+++ b/src/hooks/useSecureHubSpotData.ts
@@ -1,7 +1,7 @@
 
 import { useSupabaseClient } from './useSupabaseClient';
 import { useUser } from '@clerk/clerk-react';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import type { ContactRecord } from '@/server/search_contacts';
 
 export const useSecureHubSpotData = () => {
@@ -19,9 +19,8 @@ export const useSecureHubSpotData = () => {
     setError(null);
 
     try {
-      const { data, error: functionError } = await supabase.functions.invoke('search_contacts', {
-        query: { q: query, limit },
-      });
+      const endpoint = `search_contacts?q=${encodeURIComponent(query)}&limit=${limit}`;
+      const { data, error: functionError } = await supabase.functions.invoke(endpoint);
 
       if (functionError) {
         throw functionError;

--- a/src/hooks/useSecureSupabase.ts
+++ b/src/hooks/useSecureSupabase.ts
@@ -11,9 +11,9 @@ export const useSecureSupabase = () => {
   const [error, setError] = useState<string | null>(null);
 
   const secureQuery = useCallback(async <T>(
-    operation: () => Promise<{ data: T | null; error: any }>,
+    operation: () => Promise<{ data: T | null; error: unknown }>,
     operationType: string,
-    validation?: (data: any) => boolean
+    validation?: (data: unknown) => boolean
   ) => {
     if (!user) {
       const errorMessage = 'Authentication required for this operation';


### PR DESCRIPTION
## Summary
- remove unused import from `useSecureHubSpotData`
- send query string in contact search instead of object
- fix lint errors in `useSecureSupabase`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68628a1a59d88323ab579e58f8d80282