### PR TITLE
Align contact types with Json spec

### DIFF
--- a/src/hooks/useSecureSupabase.ts
+++ b/src/hooks/useSecureSupabase.ts
@@ -11,9 +11,9 @@ export const useSecureSupabase = () => {
   const [error, setError] = useState<string | null>(null);
 
   const secureQuery = useCallback(async <T>(
-    operation: () => Promise<{ data: T | null; error: any }>,
+    operation: () => Promise<{ data: T | null; error: unknown }>,
     operationType: string,
-    validation?: (data: any) => boolean
+    validation?: (data: T) => boolean
   ) => {
     if (!user) {
       const errorMessage = 'Authentication required for this operation';

--- a/src/integrations/hubspot/client.ts
+++ b/src/integrations/hubspot/client.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
-import type { Database } from '../supabase/types'
+import type { Database, Json } from '../supabase/types'
 import rateLimiter from '../../server/rate_limiter_memory'
 import { getSupabaseClient } from '../../server/supabaseClient'
 import { ensureAccessToken } from './tokens'
@@ -7,7 +7,7 @@ import crypto from 'crypto'
 
 export interface HubSpotContact {
   id: string
-  properties: Record<string, unknown>
+  properties: { [key: string]: Json }
 }
 
 export interface HubSpotSearchResponse {

--- a/src/pages/NewDeckFlow.tsx
+++ b/src/pages/NewDeckFlow.tsx
@@ -8,10 +8,11 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { SearchInput } from '@/components/ui/search-input';
+import type { Json } from '@/integrations/supabase/types';
 
 interface ContactResult {
   id: string;
-  properties: Record<string, unknown>;
+  properties: { [key: string]: Json };
 }
 
 const NewDeckFlow = () => {

--- a/src/server/hubspot_fetch_contacts.ts
+++ b/src/server/hubspot_fetch_contacts.ts
@@ -1,6 +1,6 @@
 
 import { type SupabaseClient } from '@supabase/supabase-js'
-import type { Database } from '../integrations/supabase/types'
+import type { Database, Json } from '../integrations/supabase/types'
 import { ensureAccessToken } from '../integrations/hubspot/tokens'
 import rateLimiter from './rate_limiter_memory'
 import { getSupabaseClient } from './supabaseClient'
@@ -9,7 +9,7 @@ const supabase = getSupabaseClient()
 
 export interface HubSpotContact {
   id: string
-  properties: Record<string, unknown>
+  properties: { [key: string]: Json }
 }
 
 export interface HubSpotSearchResponse {

--- a/src/server/search_contacts.ts
+++ b/src/server/search_contacts.ts
@@ -1,6 +1,6 @@
 
 import { type SupabaseClient } from '@supabase/supabase-js'
-import type { Database } from '../integrations/supabase/types'
+import type { Database, Json } from '../integrations/supabase/types'
 
 import {
 } from './config'
@@ -10,7 +10,7 @@ import { searchContacts as hubspotSearch } from '../integrations/hubspot/client'
 
 export interface ContactRecord {
   id: string
-  properties: Record<string, unknown>
+  properties: { [key: string]: Json }
 }
 
 // Input validation function

--- a/supabase/functions/search_contacts/index.ts
+++ b/supabase/functions/search_contacts/index.ts
@@ -9,9 +9,17 @@ const corsHeaders = {
 
 const rateLimiter = new RateLimiterMemory(10, 60000) // 10 requests per minute
 
+type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json }
+  | Json[]
+
 interface ContactRecord {
   id: string
-  properties: Record<string, unknown>
+  properties: { [key: string]: Json }
 }
 
 // Input validation function


### PR DESCRIPTION
## Summary
- use `Json` type for HubSpot contact records
- narrow generics for `secureQuery` to avoid `any`
- ensure presentation generation context is typed as Json

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68628a1d52548323b6fbf5603b831553