### PR TITLE
Remove path prop from UserProfile

### DIFF
--- a/src/hooks/useSecureSupabase.ts
+++ b/src/hooks/useSecureSupabase.ts
@@ -2,6 +2,7 @@
 import { useSupabaseClient } from './useSupabaseClient';
 import { useUser } from '@clerk/clerk-react';
 import { useState, useCallback } from 'react';
+import type { PostgrestError } from '@supabase/supabase-js';
 import { SecurityValidator, AuditLogger } from '@/server/security';
 
 export const useSecureSupabase = () => {
@@ -11,9 +12,9 @@ export const useSecureSupabase = () => {
   const [error, setError] = useState<string | null>(null);
 
   const secureQuery = useCallback(async <T>(
-    operation: () => Promise<{ data: T | null; error: any }>,
+    operation: () => Promise<{ data: T | null; error: PostgrestError | null }>,
     operationType: string,
-    validation?: (data: any) => boolean
+    validation?: (data: T) => boolean
   ) => {
     if (!user) {
       const errorMessage = 'Authentication required for this operation';

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -53,7 +53,6 @@ const ProfileContent = () => {
               </Tabs>
 
               <UserProfile
-                path={`/${activeTab}`}
                 routing="virtual"
                 appearance={{
                   variables: {


### PR DESCRIPTION
## Summary
- remove unused `path` attribute from `<UserProfile>` in Profile page
- tighten typings in `useSecureSupabase`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68628a24810c8323869c3fc6a3cda9d9