### PR TITLE
Inline Edge Function logic

### DIFF
--- a/supabase/functions/blueprints.ts
+++ b/supabase/functions/blueprints.ts
@@ -1,3 +1,230 @@
-import { handleRequest } from '../../src/server/blueprints.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.50.0'
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? ''
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+
+function getSupabaseClient(auth?: string) {
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, auth ? { global: { headers: { Authorization: auth } } } : {})
+}
+
+function parseBlueprintData(data: Record<string, unknown> | null | undefined) {
+  const {
+    goal = '',
+    audience = '',
+    section_sequence = [],
+    theme = '',
+    slide_library = [],
+    ...extra_metadata
+  } = (data || {}) as Record<string, unknown>
+
+  return {
+    goal: goal as string,
+    audience: audience as string,
+    section_sequence: section_sequence as string[],
+    theme: theme as string,
+    slide_library: slide_library as string[],
+    extra_metadata: extra_metadata as Record<string, unknown>,
+    blueprint: data as Record<string, unknown>
+  }
+}
+
+function rowToResponse(row: Record<string, any>) {
+  const {
+    blueprint_id,
+    user_id,
+    name,
+    is_default,
+    created_at,
+    updated_at,
+    goal,
+    audience,
+    section_sequence,
+    theme,
+    slide_library,
+    extra_metadata
+  } = row
+
+  return {
+    blueprint_id,
+    user_id,
+    name,
+    is_default,
+    created_at,
+    updated_at,
+    data: {
+      goal,
+      audience,
+      section_sequence,
+      theme,
+      slide_library,
+      ...(extra_metadata || {})
+    }
+  }
+}
+
+export async function handleRequest(req: Request): Promise<Response> {
+  const { method, url } = req
+  const parsed = new URL(url)
+  const auth = req.headers.get('Authorization') || ''
+  const client = getSupabaseClient(auth)
+  const { data: { user } } = await client.auth.getUser()
+  if (!user) return new Response('Unauthorized', { status: 401 })
+
+  const path = parsed.pathname.replace(/\/+/, '/').replace(/^\/+|\/+$/g, '')
+  const segments = path.split('/')
+
+  try {
+    if (segments[0] !== 'blueprints') {
+      return new Response('Not found', { status: 404 })
+    }
+
+    if (segments.length === 1) {
+      if (method === 'GET') {
+        const includeDefaults = parsed.searchParams.get('includeDefaults') === 'true'
+        const query = client.from('blueprints').select('*')
+        if (includeDefaults) {
+          query.or(`is_default.eq.true,user_id.eq.${user.id}`)
+        } else {
+          query.eq('user_id', user.id)
+        }
+        const themeFilter = parsed.searchParams.get('theme')
+        if (themeFilter) {
+          query.eq('theme', themeFilter)
+        }
+        const { data, error } = await query
+        if (error) throw error
+        return new Response(JSON.stringify(data.map(rowToResponse)), {
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+
+      if (method === 'POST') {
+        const body = await req.json()
+        const parsedData = parseBlueprintData(body.data)
+        const { data, error } = await client
+          .from('blueprints')
+          .insert({
+            user_id: user.id,
+            name: body.name,
+            blueprint: parsedData.blueprint,
+            goal: parsedData.goal,
+            audience: parsedData.audience,
+            section_sequence: parsedData.section_sequence,
+            theme: parsedData.theme,
+            slide_library: parsedData.slide_library,
+            extra_metadata: parsedData.extra_metadata
+          })
+          .select()
+          .single()
+        if (error) throw error
+        return new Response(JSON.stringify(rowToResponse(data)), {
+          headers: { 'Content-Type': 'application/json' },
+          status: 201
+        })
+      }
+    }
+
+    if (segments.length >= 2) {
+      const id = segments[1]
+      if (segments.length === 3 && segments[2] === 'clone' && method === 'POST') {
+        const { data: orig, error } = await client
+          .from('blueprints')
+          .select('*')
+          .eq('blueprint_id', id)
+          .single()
+        if (error) return new Response('Not Found', { status: 404 })
+        if (!orig.is_default) return new Response('Not Found', { status: 404 })
+        const { data, error: insertError } = await client
+          .from('blueprints')
+          .insert({
+            user_id: user.id,
+            name: orig.name,
+            blueprint: orig.blueprint,
+            goal: orig.goal,
+            audience: orig.audience,
+            section_sequence: orig.section_sequence,
+            theme: orig.theme,
+            slide_library: orig.slide_library,
+            extra_metadata: orig.extra_metadata
+          })
+          .select()
+          .single()
+        if (insertError) throw insertError
+        return new Response(JSON.stringify(rowToResponse(data)), {
+          headers: { 'Content-Type': 'application/json' },
+          status: 201
+        })
+      }
+
+      if (segments.length === 2) {
+        if (method === 'GET') {
+          const { data, error } = await client
+            .from('blueprints')
+            .select('*')
+            .eq('blueprint_id', id)
+            .maybeSingle()
+          if (error || !data) return new Response('Not Found', { status: 404 })
+          if (!data.is_default && data.user_id !== user.id) {
+            return new Response('Not Found', { status: 404 })
+          }
+          return new Response(JSON.stringify(rowToResponse(data)), {
+            headers: { 'Content-Type': 'application/json' }
+          })
+        }
+
+        if (method === 'PUT') {
+          const { data: existing, error } = await client
+            .from('blueprints')
+            .select('is_default')
+            .eq('blueprint_id', id)
+            .maybeSingle()
+          if (error || !existing) return new Response('Not Found', { status: 404 })
+          if (existing.is_default) return new Response('Forbidden', { status: 403 })
+          const body = await req.json()
+          const parsedData = parseBlueprintData(body.data)
+          const { error: upError } = await client
+            .from('blueprints')
+            .update({
+              name: body.name,
+              blueprint: parsedData.blueprint,
+              goal: parsedData.goal,
+              audience: parsedData.audience,
+              section_sequence: parsedData.section_sequence,
+              theme: parsedData.theme,
+              slide_library: parsedData.slide_library,
+              extra_metadata: parsedData.extra_metadata,
+              updated_at: new Date().toISOString()
+            })
+            .eq('blueprint_id', id)
+            .eq('user_id', user.id)
+          if (upError) throw upError
+          return new Response(null, { status: 200 })
+        }
+
+        if (method === 'DELETE') {
+          const { data: existing, error } = await client
+            .from('blueprints')
+            .select('is_default, user_id')
+            .eq('blueprint_id', id)
+            .maybeSingle()
+          if (error || !existing) return new Response('Not Found', { status: 404 })
+          if (existing.is_default) return new Response('Forbidden', { status: 403 })
+          if (existing.user_id !== user.id) return new Response('Not Found', { status: 404 })
+          const { error: delError } = await client
+            .from('blueprints')
+            .delete()
+            .eq('blueprint_id', id)
+          if (delError) throw delError
+          return new Response(null, { status: 204 })
+        }
+      }
+    }
+
+    return new Response('Not found', { status: 404 })
+  } catch (err) {
+    console.error('Blueprint handler error:', err)
+    return new Response('Internal server error', { status: 500 })
+  }
+}
 
 Deno.serve(handleRequest)

--- a/supabase/functions/hubspot_fetch_contacts.ts
+++ b/supabase/functions/hubspot_fetch_contacts.ts
@@ -1,3 +1,158 @@
-import { handleRequest } from '../../src/server/hubspot_fetch_contacts.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.50.0'
+
+class RateLimiterMemory {
+  private requests = new Map<string, number[]>()
+  constructor(private maxRequests: number, private windowMs: number) {}
+
+  async take(key: string): Promise<void> {
+    const now = Date.now()
+    const requests = this.requests.get(key) || []
+    const valid = requests.filter(t => now - t < this.windowMs)
+    if (valid.length >= this.maxRequests) {
+      const oldest = Math.min(...valid)
+      const wait = this.windowMs - (now - oldest)
+      if (wait > 0) {
+        await new Promise(res => setTimeout(res, wait))
+        return this.take(key)
+      }
+    }
+    valid.push(now)
+    this.requests.set(key, valid)
+  }
+}
+
+const rateLimiter = new RateLimiterMemory(100, 1000)
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? ''
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+const HUBSPOT_CLIENT_ID = Deno.env.get('HUBSPOT_CLIENT_ID') ?? ''
+const HUBSPOT_CLIENT_SECRET = Deno.env.get('HUBSPOT_CLIENT_SECRET') ?? ''
+
+function getSupabaseClient() {
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+}
+
+async function ensureAccessToken(portalId: string, sb = getSupabaseClient() ) {
+  const { data: tokenData, error } = await sb
+    .from('hubspot_tokens')
+    .select('access_token, refresh_token, expires_at')
+    .eq('portal_id', portalId)
+    .maybeSingle()
+
+  if (error || !tokenData) {
+    throw new Error('No HubSpot token found')
+  }
+
+  const expiresAt = new Date(tokenData.expires_at ?? '')
+  const needsRefresh = expiresAt.getTime() <= Date.now() + 300000
+
+  if (needsRefresh && tokenData.refresh_token) {
+    const resp = await fetch('https://api.hubapi.com/oauth/v1/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: HUBSPOT_CLIENT_ID,
+        client_secret: HUBSPOT_CLIENT_SECRET,
+        refresh_token: tokenData.refresh_token
+      })
+    })
+
+    if (resp.ok) {
+      const data = await resp.json()
+      await sb.from('hubspot_tokens').update({
+        access_token: data.access_token,
+        refresh_token: data.refresh_token || tokenData.refresh_token,
+        expires_at: new Date(Date.now() + data.expires_in * 1000).toISOString()
+      }).eq('portal_id', portalId)
+      return data.access_token as string
+    }
+  }
+
+  return tokenData.access_token as string
+}
+
+const supabase = getSupabaseClient()
+
+export interface HubSpotContact {
+  id: string
+  properties: Record<string, unknown>
+}
+
+export interface HubSpotSearchResponse {
+  results: HubSpotContact[]
+}
+
+export async function hubspotFetchContacts(
+  portal_id: string,
+  after?: string,
+  sb = supabase,
+  fetchFn: typeof fetch = fetch,
+): Promise<void> {
+  const accessToken = await ensureAccessToken(portal_id, sb)
+  await rateLimiter.take(portal_id)
+
+  const body: Record<string, unknown> = {
+    limit: 100,
+    sorts: ['hs_lastmodifieddate'],
+    properties: ['firstname', 'lastname', 'email', 'hs_lastmodifieddate']
+  }
+  if (after) {
+    body.filterGroups = [{
+      filters: [{ propertyName: 'hs_lastmodifieddate', operator: 'GT', value: after }]
+    }]
+  }
+
+  const resp = await fetchFn('https://api.hubapi.com/crm/v3/objects/contacts/search', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  })
+
+  if (!resp.ok) throw new Error('HubSpot fetch failed')
+  const json: HubSpotSearchResponse = await resp.json()
+  const results = json.results || []
+
+  if (results.length) {
+    const rows = results.map(r => ({
+      portal_id,
+      id: r.id,
+      properties: r.properties,
+      updated_at: (r.properties.hs_lastmodifieddate as string) || new Date().toISOString()
+    }))
+    await sb.from('hubspot_contacts_cache').upsert(rows)
+
+    const last = rows.reduce<string | undefined>((max, r) => {
+      const ts = r.updated_at as string
+      if (!max || ts > max) return ts
+      return max
+    }, after)
+
+    if (last) {
+      await sb.from('hubspot_sync_cursors').upsert({ portal_id, object_type: 'contacts', hs_timestamp: last })
+    }
+  }
+}
+
+export async function handleRequest(req: Request): Promise<Response> {
+  const url = new URL(req.url)
+  const portal_id = url.searchParams.get('portal_id') || ''
+  const after = url.searchParams.get('after') || undefined
+
+  if (!portal_id) {
+    return new Response('portal_id required', { status: 400 })
+  }
+
+  try {
+    await hubspotFetchContacts(portal_id, after)
+    return new Response(null, { status: 204 })
+  } catch (err) {
+    console.error('hubspotFetchContacts error:', err)
+    return new Response('Internal server error', { status: 500 })
+  }
+}
 
 Deno.serve(handleRequest)

--- a/supabase/functions/section-templates.ts
+++ b/supabase/functions/section-templates.ts
@@ -1,3 +1,48 @@
-import { handleRequest } from '../../src/server/section_templates.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.50.0'
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? ''
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+
+export async function handleRequest(req: Request): Promise<Response> {
+  const url = new URL(req.url)
+  const segments = url.pathname.replace(/^\/+|\/+$/g, '').split('/')
+
+  if (segments[0] !== 'section-templates') {
+    return new Response('Not found', { status: 404 })
+  }
+
+  try {
+    if (req.method === 'GET') {
+      if (segments.length === 1) {
+        const { data, error } = await supabase
+          .from('section_templates')
+          .select('*')
+        if (error) throw error
+        return new Response(JSON.stringify(data), {
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+      if (segments.length === 2) {
+        const id = segments[1]
+        const { data, error } = await supabase
+          .from('section_templates')
+          .select('*')
+          .eq('section_id', id)
+          .maybeSingle()
+        if (error) throw error
+        if (!data) return new Response('Not Found', { status: 404 })
+        return new Response(JSON.stringify(data), {
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+    }
+    return new Response('Not found', { status: 404 })
+  } catch (err) {
+    console.error('Section templates handler error:', err)
+    return new Response('Internal server error', { status: 500 })
+  }
+}
 
 Deno.serve(handleRequest)

--- a/supabase/functions/sections.ts
+++ b/supabase/functions/sections.ts
@@ -1,3 +1,129 @@
-import { handleRequest } from '../../src/server/sections.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.50.0'
+import OpenAI from 'npm:openai'
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? ''
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+
+function getSupabaseClient(auth?: string) {
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, auth ? { global: { headers: { Authorization: auth } } } : {})
+}
+
+interface Rule {
+  goalPatterns: string[]
+  audiencePatterns: string[]
+  sections: string[]
+}
+
+const ruleSet: Rule[] = [
+  {
+    goalPatterns: ['quarterly review', 'business review', 'qbr'],
+    audiencePatterns: ['executive', 'leadership', 'board'],
+    sections: ['intro', 'highlights', 'metrics', 'roadmap', 'q_and_a']
+  },
+  {
+    goalPatterns: ['project proposal', 'proposal', 'pitch'],
+    audiencePatterns: ['investor', 'stakeholder', 'client'],
+    sections: ['intro', 'problem', 'solution', 'benefits', 'costs', 'next_steps', 'q_and_a']
+  },
+  {
+    goalPatterns: ['training', 'onboarding', 'tutorial'],
+    audiencePatterns: ['new hire', 'employee', 'team'],
+    sections: ['intro', 'agenda', 'overview', 'lesson', 'exercise', 'summary']
+  },
+  {
+    goalPatterns: ['sales pitch', 'sales presentation'],
+    audiencePatterns: ['customer', 'prospect'],
+    sections: ['intro', 'need', 'solution', 'case_study', 'pricing', 'next_steps', 'q_and_a']
+  },
+  {
+    goalPatterns: ['product demo', 'demo'],
+    audiencePatterns: ['prospect', 'client'],
+    sections: ['intro', 'features', 'demo', 'benefits', 'pricing', 'q_and_a']
+  }
+]
+
+interface CacheEntry {
+  sections: string[]
+  expires: number
+}
+
+const cache = new Map<string, CacheEntry>()
+
+const demoPairs = [
+  { goal: 'Quarterly Business Review', audience: 'executive team' },
+  { goal: 'Project Proposal', audience: 'stakeholder' },
+  { goal: 'Training', audience: 'new hire' },
+  { goal: 'Sales Pitch', audience: 'customer' },
+  { goal: 'Product Demo', audience: 'prospect' }
+]
+
+for (const { goal, audience } of demoPairs) {
+  const g = goal.toLowerCase()
+  const a = audience.toLowerCase()
+  const rule = ruleSet.find(r =>
+    r.goalPatterns.some(p => g.includes(p)) &&
+    r.audiencePatterns.some(p => a.includes(p))
+  )
+  if (rule) {
+    const key = `${g}|${a}|0`
+    cache.set(key, { sections: rule.sections, expires: Date.now() + 30 * 24 * 60 * 60 * 1000 })
+  }
+}
+
+const openai = new OpenAI()
+
+export async function handleRequest(req: Request): Promise<Response> {
+  const url = new URL(req.url)
+  const path = url.pathname.replace(/^\/+|\/+$/g, '')
+
+  const normalized = path.replace(/^api\//, '')
+  if (normalized !== 'sections/suggest' || req.method !== 'POST') {
+    return new Response('Not found', { status: 404 })
+  }
+
+  const auth = req.headers.get('Authorization') || ''
+  const client = getSupabaseClient(auth)
+  const { data: { user } } = await client.auth.getUser()
+  if (!user) return new Response('Unauthorized', { status: 401 })
+
+  const { goal = '', audience = '', creative = false } = await req.json()
+
+  const key = `${goal.toLowerCase()}|${audience.toLowerCase()}|${creative ? 1 : 0}`
+  const cached = cache.get(key)
+  if (cached && cached.expires > Date.now()) {
+    return new Response(JSON.stringify({ sections: cached.sections }), {
+      headers: { 'Content-Type': 'application/json' }
+    })
+  }
+
+  const g = goal.toLowerCase()
+  const a = audience.toLowerCase()
+  const rule = !creative && ruleSet.find(r =>
+    r.goalPatterns.some(p => g.includes(p)) &&
+    r.audiencePatterns.some(p => a.includes(p))
+  )
+
+  let sections: string[]
+  if (rule) {
+    sections = rule.sections
+  } else {
+    try {
+      const completion = await openai.chat.completions.create({
+        model: 'gpt-4.1-nano',
+        max_tokens: 50,
+        messages: [{ role: 'user', content: `Suggest 5–7 section IDs for goal="${goal}" and audience="${audience}".` }]
+      })
+      sections = JSON.parse(completion.choices[0].message.content || '[]')
+    } catch (err) {
+      console.error('Section suggest error:', err)
+      sections = ['intro', 'context', 'analysis', 'recommendation', 'q_and_a']
+    }
+  }
+
+  cache.set(key, { sections, expires: Date.now() + 24 * 60 * 60 * 1000 })
+  return new Response(JSON.stringify({ sections }), {
+    headers: { 'Content-Type': 'application/json' }
+  })
+}
 
 Deno.serve(handleRequest)

--- a/supabase/functions/slide-templates.ts
+++ b/supabase/functions/slide-templates.ts
@@ -1,3 +1,92 @@
-import { handleRequest } from '../../src/server/slide_templates.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.50.0'
+
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? ''
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+
+export async function handleRequest(req: Request): Promise<Response> {
+  const url = new URL(req.url)
+  const segments = url.pathname.replace(/^\/+|\/+$/g, '').split('/')
+
+  if (segments[0] !== 'slide-templates') {
+    return new Response('Not found', { status: 404 })
+  }
+
+  try {
+    if (req.method === 'GET') {
+      if (segments.length === 1) {
+        const { data, error } = await supabase
+          .from('slide_templates')
+          .select('*')
+        if (error) throw error
+        return new Response(JSON.stringify(data), {
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+      if (segments.length === 2) {
+        const id = segments[1]
+        const { data, error } = await supabase
+          .from('slide_templates')
+          .select('*')
+          .eq('template_id', id)
+          .maybeSingle()
+        if (error) throw error
+        if (!data) return new Response('Not Found', { status: 404 })
+        return new Response(JSON.stringify(data), {
+          headers: { 'Content-Type': 'application/json' }
+        })
+      }
+    }
+
+    if (req.method === 'POST' && segments.length === 1) {
+      const body = await req.json()
+      const { data, error } = await supabase
+        .from('slide_templates')
+        .insert(body)
+        .select()
+        .single()
+      if (error) throw error
+      return new Response(JSON.stringify(data), {
+        headers: { 'Content-Type': 'application/json' },
+        status: 201
+      })
+    }
+
+    if (req.method === 'PUT' && segments.length === 2) {
+      const id = segments[1]
+      const body = await req.json()
+      const { data, error } = await supabase
+        .from('slide_templates')
+        .update({ ...body, updated_at: new Date().toISOString() })
+        .eq('template_id', id)
+        .select()
+        .maybeSingle()
+      if (error) throw error
+      if (!data) return new Response('Not Found', { status: 404 })
+      return new Response(JSON.stringify(data), {
+        headers: { 'Content-Type': 'application/json' }
+      })
+    }
+
+    if (req.method === 'DELETE' && segments.length === 2) {
+      const id = segments[1]
+      const { data, error } = await supabase
+        .from('slide_templates')
+        .delete()
+        .eq('template_id', id)
+        .select('template_id')
+        .maybeSingle()
+      if (error) throw error
+      if (!data) return new Response('Not Found', { status: 404 })
+      return new Response(null, { status: 204 })
+    }
+
+    return new Response('Not found', { status: 404 })
+  } catch (err) {
+    console.error('Slide templates handler error:', err)
+    return new Response('Internal server error', { status: 500 })
+  }
+}
 
 Deno.serve(handleRequest)


### PR DESCRIPTION
## Summary
- make edge functions independent from src/ directory by inlining code
- ensure HubSpot fetch uses internal rate limiter and token refresh logic

## Testing
- `npm run lint -- --fix`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6862e0d62ffc8323a651b04db7d2a1ff