### PR TITLE
Add Clerk fields to profiles table

### DIFF
--- a/supabase/migrations/20250707000001-profiles_clerk_fields.sql
+++ b/supabase/migrations/20250707000001-profiles_clerk_fields.sql
@@ -1,0 +1,18 @@
+-- Add Clerk fields to existing profiles table
+ALTER TABLE public.profiles
+  ADD COLUMN avatar_url TEXT,
+  ADD COLUMN metadata JSONB;
+
+-- Ensure updated_at timestamp updates on change
+CREATE OR REPLACE FUNCTION public.update_profile_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS profiles_updated_at ON public.profiles;
+CREATE TRIGGER profiles_updated_at
+  BEFORE UPDATE ON public.profiles
+  FOR EACH ROW EXECUTE FUNCTION public.update_profile_timestamp();


### PR DESCRIPTION
## Summary
- remove unneeded `clerk_users` migration
- extend existing `profiles` table with `avatar_url` and `metadata`
- add trigger to keep `updated_at` current

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run preview` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_b_6864b06f42848323b793cda291830694