### PR TITLE
Add dashboard presentation actions

### DIFF
--- a/src/components/dashboard/DeckList.tsx
+++ b/src/components/dashboard/DeckList.tsx
@@ -1,10 +1,40 @@
 
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Eye, Edit, Download } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { useDecks } from '@/hooks/useDecks';
+import { exportDeck } from '@/lib/exportDeck';
+import { convertPuckToSlides } from '@/components/presentation/utils/slideDataConverter';
+import { toast } from '@/components/ui/use-toast';
 
 const DeckList = () => {
-  const { decks, loading } = useDecks();
+  const navigate = useNavigate();
+  const { decks, loading, getSlides } = useDecks();
+
+  const handleView = (id: string) => {
+    navigate(`/view/${id}?mode=view`);
+  };
+
+  const handleEdit = (id: string) => {
+    navigate(`/view/${id}?mode=edit`);
+  };
+
+  const handleDownload = async (id: string, title: string) => {
+    const slideData = await getSlides(id);
+    if (!slideData) {
+      toast({
+        title: 'Download Failed',
+        description: 'Unable to fetch slides for this deck.',
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    const slides = convertPuckToSlides(slideData);
+    await exportDeck(slides, `${title}.pptx`);
+  };
 
   return (
     <Card className="border-gray-200 bg-white">
@@ -14,10 +44,36 @@ const DeckList = () => {
         {!loading && decks.length === 0 && (
           <p className="text-sm text-gray-600">No decks found</p>
         )}
-        <ul className="space-y-1">
+        <ul className="space-y-2">
           {decks.map((deck) => (
-            <li key={deck.id} className="text-sm text-slate-gray">
-              {deck.title}
+            <li key={deck.id} className="flex items-center justify-between">
+              <span className="text-sm text-slate-gray">{deck.title}</span>
+              <div className="flex gap-1">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="View deck"
+                  onClick={() => handleView(deck.id)}
+                >
+                  <Eye className="w-4 h-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Edit deck"
+                  onClick={() => handleEdit(deck.id)}
+                >
+                  <Edit className="w-4 h-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Download deck"
+                  onClick={() => handleDownload(deck.id, deck.title)}
+                >
+                  <Download className="w-4 h-4" />
+                </Button>
+              </div>
             </li>
           ))}
         </ul>

--- a/src/pages/PresentDeck.tsx
+++ b/src/pages/PresentDeck.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { useSupabaseClient } from "@/hooks/useSupabaseClient";
 import PresentationController from "@/components/presentation/PresentationController";
 import { PresentationMode } from "@/components/presentation/types";
@@ -10,10 +10,12 @@ import { toast } from "sonner";
 const PresentDeck = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const supabase = useSupabaseClient();
   const [slides, setSlides] = useState<Slide[]>([]);
   const [loading, setLoading] = useState(true);
-  const [mode, setMode] = useState<PresentationMode>('present');
+  const initialModeParam = searchParams.get('mode') as PresentationMode | null;
+  const [mode, setMode] = useState<PresentationMode>(initialModeParam || 'present');
   const [presentation, setPresentation] = useState<any>(null);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- update PresentDeck to read `mode` query param
- extend DeckList with view/edit/download buttons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6865e573622883238dd257aa418b1e39