### PR TITLE
Add dashboard button to hero

### DIFF
--- a/src/components/ModernHero.tsx
+++ b/src/components/ModernHero.tsx
@@ -4,6 +4,8 @@ import { ArrowRight, Sparkles } from 'lucide-react';
 import ThreadingAnimation from './ThreadingAnimation';
 import ClerkWaitlistForm from './ClerkWaitlistForm';
 import { Button } from './ui/button';
+import { SignedIn } from '@clerk/clerk-react';
+import { Link } from 'react-router-dom';
 import { containerVariants, itemVariants } from '../lib/variants';
 const ModernHero = () => {
   const handleWatchDemo = () => {
@@ -45,10 +47,18 @@ const ModernHero = () => {
           </motion.div>
 
           {/* Secondary CTA */}
-          <motion.div variants={itemVariants} className="flex justify-center mb-16">
+          <motion.div
+            variants={itemVariants}
+            className="flex flex-col sm:flex-row justify-center items-center gap-4 mb-16"
+          >
             <Button variant="outline" className="btn-secondary" onClick={handleWatchDemo}>
               Watch Demo
             </Button>
+            <SignedIn>
+              <Button asChild className="btn-primary">
+                <Link to="/dashboard">Go to Dashboard</Link>
+              </Button>
+            </SignedIn>
           </motion.div>
         </div>
       </motion.div>


### PR DESCRIPTION
## Summary
- add `SignedIn` dashboard button on home page hero section

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68667516f6788323a4599e40d1313af9