### PR TITLE
Switch to Clerk's native Supabase integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,19 +223,19 @@ This application features a sophisticated slide presentation system with the fol
 
 ### Authentication Configuration
 
-This project uses Clerk for authentication with Supabase as the backend. The integration is configured to pass Clerk session tokens directly to Supabase:
+This project uses Clerk for authentication with Supabase as the backend. The native integration passes Clerk tokens to Supabase using a helper hook:
 
 ```typescript
 import { createClient } from '@supabase/supabase-js'
-import { useSession } from '@clerk/clerk-react'
+import { useAuth } from '@clerk/clerk-react'
 
-const { session } = useSession()
+const { getToken } = useAuth()
 
 const client = createClient(
   'https://your-project.supabase.co',
   'your-anon-key',
   {
-    accessToken: () => session?.getToken(),
+    accessToken: getToken,
   },
 )
 ```

--- a/agents.md
+++ b/agents.md
@@ -223,15 +223,15 @@ When integrating Clerk with Supabase, follow these exact patterns:
 **✅ Correct Supabase Client Configuration:**
 ```typescript
 import { createClient } from '@supabase/supabase-js'
-import { useSession } from '@clerk/clerk-react'
+import { useAuth } from '@clerk/clerk-react'
 
-const { session } = useSession()
+const { getToken } = useAuth()
 
 const client = createClient(
   supabaseUrl,
   supabaseAnonKey,
   {
-    accessToken: session ? () => session.getToken() : undefined,
+    accessToken: getToken,
   },
 )
 ```
@@ -241,7 +241,7 @@ const client = createClient(
 // DON'T use Bearer headers - this causes auth conflicts
 global: {
   headers: {
-    'Authorization': `Bearer ${session.getToken()}`,
+    'Authorization': `Bearer ${await getToken()}`,
   },
 },
 ```

--- a/src/hooks/useFileUpload.ts
+++ b/src/hooks/useFileUpload.ts
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 import { useSupabaseClient } from './useSupabaseClient';
-import { useSession } from '@clerk/clerk-react';
+import { useAuth } from '@clerk/clerk-react';
 
 export const useFileUpload = () => {
   const supabase = useSupabaseClient();
-  const { session } = useSession();
+  const { getToken, userId } = useAuth();
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -13,13 +13,11 @@ export const useFileUpload = () => {
       setUploading(true);
       setError(null);
       
-      if (!session) {
+      if (!userId) {
         throw new Error('No authentication session');
       }
-      
-      const token = await session.getToken();
-      const payload = JSON.parse(atob(token.split('.')[1]));
-      const userId = payload.sub;
+
+      const token = await getToken();
       
       const filePath = `${userId}/${Date.now()}-${file.name}`;
       const { error: uploadError } = await supabase.storage

--- a/src/hooks/usePresentationJobs.ts
+++ b/src/hooks/usePresentationJobs.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useSupabaseClient } from '@/hooks/useSupabaseClient';
-import { useSession } from '@clerk/clerk-react';
+import { useAuth } from '@clerk/clerk-react';
 import { useToast } from '@/hooks/use-toast';
 
 export interface PresentationInput {
@@ -33,7 +33,7 @@ export const usePresentationJobs = () => {
   const [jobs, setJobs] = useState<PresentationJob[]>([]);
   const [loading, setLoading] = useState(true);
   const supabase = useSupabaseClient();
-  const { session } = useSession();
+  const { getToken } = useAuth();
   const { toast } = useToast();
 
   const fetchJobs = async () => {
@@ -70,11 +70,7 @@ export const usePresentationJobs = () => {
     slide_count_preference?: number;
   }) => {
     try {
-      if (!session) {
-        throw new Error('No active session');
-      }
-
-      const token = await session.getToken();
+      const token = await getToken();
       if (!token) {
         throw new Error('Failed to get authentication token');
       }

--- a/src/hooks/useSupabaseClient.ts
+++ b/src/hooks/useSupabaseClient.ts
@@ -1,12 +1,12 @@
 import { useMemo } from "react";
-import { useSession } from "@clerk/clerk-react";
+import { useAuth } from "@clerk/clerk-react";
 import { createClient } from "@supabase/supabase-js";
 
 const supabaseUrl = 'https://igspkppkbqbbxffhdqlq.supabase.co';
 const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imlnc3BrcHBrYnFiYnhmZmhkcWxxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAzMDEyNjUsImV4cCI6MjA2NTg3NzI2NX0.ilzySO3FegN_Ry21cBngROOasL_mZbNkF3OMMneCPFk';
 
 export const useSupabaseClient = () => {
-  const { session } = useSession();
+  const { getToken } = useAuth();
 
   const supabase = useMemo(() => {
     return createClient(supabaseUrl, supabaseAnonKey, {
@@ -19,9 +19,9 @@ export const useSupabaseClient = () => {
           'x-client-info': 'lovable-app',
         },
       },
-      accessToken: session ? () => session.getToken() : undefined,
+      accessToken: getToken,
     });
-  }, [session]);
+  }, [getToken]);
 
   return supabase;
 };


### PR DESCRIPTION
## Summary
- update Supabase client hook to use `useAuth` instead of `useSession`
- adjust file upload and presentation job hooks for new token retrieval
- update documentation with new code examples for Clerk + Supabase
- refresh agent guidelines to match the native integration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6869665172d883238859b1a5bf3fdbc1